### PR TITLE
Better reminder support for Microsoft To-Do

### DIFF
--- a/content/includes/tasksync.js
+++ b/content/includes/tasksync.js
@@ -78,7 +78,7 @@ var Tasks = {
                 // drawback: only works if due date and reminder is set to the same day - this could maybe checked here but I don't know how
                 item.entryDate = UtcAlarmDate;
                 item.dueDate = UtcAlarmDate;
-                alarm.related = Components.interfaces.calIAlarm.ALARM_RELATED_END;
+                alarm.related = Components.interfaces.calIAlarm.ALARM_RELATED_START;
                 alarm.offset = TbSync.lightning.cal.createDuration();
                 alarm.offset.inSeconds = 0;
             }
@@ -86,7 +86,7 @@ var Tasks = {
             {
                 let UtcDate = eas.tools.createDateTime(data.UtcStartDate);
                 alarm.related = Components.interfaces.calIAlarm.ALARM_RELATED_START;
-		alarm.offset = UtcAlarmDate.subtractDate(UtcDate);
+                alarm.offset = UtcAlarmDate.subtractDate(UtcDate);
             }
             else
             {

--- a/content/includes/tasksync.js
+++ b/content/includes/tasksync.js
@@ -8,6 +8,16 @@
  
  "use strict";
 
+var { XPCOMUtils } = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+
+XPCOMUtils.defineLazyModuleGetters(this, {
+ CalAlarm: "resource:///modules/CalAlarm.jsm",
+ CalAttachment: "resource:///modules/CalAttachment.jsm",
+ CalAttendee: "resource:///modules/CalAttendee.jsm",
+ CalEvent: "resource:///modules/CalEvent.jsm",
+ CalTodo: "resource:///modules/CalTodo.jsm",
+}); 
+
 var Tasks = {
 
     // --------------------------------------------------------------------------- //

--- a/content/includes/tasksync.js
+++ b/content/includes/tasksync.js
@@ -73,14 +73,38 @@ var Tasks = {
         eas.sync.mapEasPropertyToThunderbird ("Sensitivity", "CLASS", data, item);
         eas.sync.mapEasPropertyToThunderbird ("Importance", "PRIORITY", data, item);
 
+        let msTodoCompat = eas.prefs.getBoolPref("msTodoCompat");
+        
         item.clearAlarms();
-        if (data.ReminderSet && data.ReminderTime && data.UtcStartDate) {        
-            let UtcDate = eas.tools.createDateTime(data.UtcStartDate);
+        if (data.ReminderSet && data.ReminderTime) {
             let UtcAlarmDate = eas.tools.createDateTime(data.ReminderTime);
             let alarm = new CalAlarm();
-            alarm.related = Components.interfaces.calIAlarm.ALARM_RELATED_START; //TB saves new alarms as offsets, so we add them as such as well
-            alarm.offset = UtcAlarmDate.subtractDate(UtcDate);
             alarm.action = "DISPLAY";
+            
+            if (msTodoCompat)
+            {
+                // Microsoft To-Do only uses due dates (no start dates) an doesn't have a time part in the due date
+                // dirty hack: Use the reminder date as due date and set a reminder exactly to the due date
+                // drawback: only works if due date and reminder is set to the same day - this could maybe checked here but I don't know how
+                item.entryDate = UtcAlarmDate;
+                item.dueDate = UtcAlarmDate;
+                alarm.related = Components.interfaces.calIAlarm.ALARM_RELATED_START;
+                alarm.offset = TbSync.lightning.cal.createDuration();
+                alarm.offset.inSeconds = 0;
+            }
+            else if (data.UtcStartDate)
+            {
+                let UtcDate = eas.tools.createDateTime(data.UtcStartDate);
+                alarm.related = Components.interfaces.calIAlarm.ALARM_RELATED_START;
+                alarm.offset = UtcAlarmDate.subtractDate(UtcDate);
+            }
+            else
+            {
+                // Alternative solution for Microsoft To-Do:
+                // alarm correctly set but because time part of due date is always "0:00", all tasks for today are shown as overdue
+                alarm.related = Components.interfaces.calIAlarm.ALARM_RELATED_ABSOLUTE;
+                alarm.alarmDate = UtcAlarmDate;
+            }
             item.addAlarm(alarm);
         }
         

--- a/content/provider.js
+++ b/content/provider.js
@@ -38,7 +38,6 @@ var Base = class {
         let branch = Services.prefs.getDefaultBranch("extensions.eas4tbsync.");
         branch.setIntPref("timeout", 90000);
         branch.setIntPref("maxitems", 50);
-        branch.setBoolPref("msTodoCompat", false);
         branch.setCharPref("clientID.type", "TbSync");
         branch.setCharPref("clientID.useragent", "Thunderbird ActiveSync");    
 

--- a/content/provider.js
+++ b/content/provider.js
@@ -38,6 +38,7 @@ var Base = class {
         let branch = Services.prefs.getDefaultBranch("extensions.eas4tbsync.");
         branch.setIntPref("timeout", 90000);
         branch.setIntPref("maxitems", 50);
+        branch.setBoolPref("msTodoCompat", false);
         branch.setCharPref("clientID.type", "TbSync");
         branch.setCharPref("clientID.useragent", "Thunderbird ActiveSync");    
 


### PR DESCRIPTION
I've added some changes to better support Microsoft To Do (https://todo.microsoft.com/).

Microsoft To Do:

- only uses due dates (no start dates - because of this reminders do not work currently in EAS-4-TbSync)
- the due date doen't have a time part (time is set to 0:00)
- reminders have an absolute date +time

My patch adds a new preference "extensions.eas4tbsync.msTodoCompat=true/false" (defaults to "false").
When downloading new tasks from the server and the parameter is set to

- **true**, the reminder date itself will be used as the due date _and_ entry date. Additionally a reminder will be created, that points exactly to the entry date (related to entry date with 0 seconds offset). Drawback: it completly ignores the due date from MS To Do. Hence it only makes sense if due date and reminder is set to the same day (but who uses different days for date and reminder in MS To Do?).
- **false** and start date has not been transmitted by server (which is the case for MS To Do), the entry date and due date will be set as usual. Only difference: reminder is created using an absolute time instead of relative date based on start date. Drawback: Because MS To Do does not use time parts in and due, it's always shown as "0:00". Which means all tasks for today are shown as overdue even if the reminder is defined for a later time on that day.

"msTodoCompat=false" is for sure the prefered way since it honors the due date. "msTodoCompat=true" works best for my personal use.