### PR TITLE
Fix O365 custom client ID setup

### DIFF
--- a/content/includes/network.js
+++ b/content/includes/network.js
@@ -78,7 +78,7 @@ var network = {
     let config = {};
     switch (host) {
       case "outlook.office365.com":
-        let customID = accountData.getAccountProperty("oauthClientID");
+        let customID = eas.Base.getCustomeOauthClientID();
         config = {
           auth_uri : "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
           token_uri : "https://login.microsoftonline.com/common/oauth2/v2.0/token",

--- a/content/provider.js
+++ b/content/provider.js
@@ -266,7 +266,6 @@ var Base = class {
             "allowedEasCommands": "",
             "useragent": eas.prefs.getCharPref("clientID.useragent"),
             "devicetype": eas.prefs.getCharPref("clientID.type"),
-            "oauthClientID": eas.prefs.getCharPref("oauth.clientID"),
             "synclimit" : "7",
             }; 
         return row;
@@ -441,6 +440,14 @@ var Base = class {
 
         // Fall through, if there was no error.
         return new TbSync.StatusData();   
+    }
+
+
+    /**
+     * Return the custom OAuth2 ClientID.
+     */
+    static getCustomeOauthClientID() {
+        return eas.prefs.getCharPref("oauth.clientID");
     }
 }
 


### PR DESCRIPTION
This was broken in 94fbf4ad: accountData is null during account setup, causing the customID initialization and, thus, the complete account creation to fail.

In fact, the client ID is not an account property, it's global. Therefore introduce getCustomeOauthClientID to obtain this property independent or the account.

Should resolve #223.