### PR TITLE
Update addon-developer-support and use Services global variable if possible

### DIFF
--- a/content/api/BootstrapLoader/CHANGELOG.md
+++ b/content/api/BootstrapLoader/CHANGELOG.md
@@ -1,3 +1,7 @@
+Version: 1.22
+-------------
+- adjusted to Thunderbird Supernova (Services is now in globalThis)
+
 Version: 1.21
 -------------
 - Explicitly set hasAddonManagerEventListeners flag to false on uninstall

--- a/content/api/BootstrapLoader/implementation.js
+++ b/content/api/BootstrapLoader/implementation.js
@@ -2,7 +2,7 @@
  * This file is provided by the addon-developer-support repository at
  * https://github.com/thundernest/addon-developer-support
  *
- * Version: 1.21
+ * Version 1.22
  *
  * Author: John Bieling (john@thunderbird.net)
  *
@@ -15,7 +15,8 @@
 var { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
 var { ExtensionSupport } = ChromeUtils.import("resource:///modules/ExtensionSupport.jsm");
 var { AddonManager } = ChromeUtils.import("resource://gre/modules/AddonManager.jsm");
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var Services = globalThis.Services || 
+  ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
 
 function getThunderbirdVersion() {
   let parts = Services.appinfo.version.split(".");

--- a/content/bootstrap.js
+++ b/content/bootstrap.js
@@ -8,7 +8,9 @@
 
 // no need to create namespace, we are in a sandbox
 
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 
 let onInitDoneObserver = {
     observe: async function (aSubject, aTopic, aData) {        


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 .
Services global variable is available in WebExtensions experiments API global
from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 ,
and also available in all system globals from version 104
https://bugzilla.mozilla.org/show_bug.cgi?id=1667455 ,
and those code doesn't have to import Services.jsm for recent versions.