### PR TITLE
fix: ensure getTimezoneInfoObject returns latest timezone offset (#293)

### DIFF
--- a/content/includes/tools.js
+++ b/content/includes/tools.js
@@ -460,7 +460,11 @@ var tools = {
         let comp = new TbSync.lightning.ICAL.Component(info);
         let vtimezone = comp.getFirstSubcomponent("vtimezone");
         let id = vtimezone.getFirstPropertyValue("tzid").toString();
-        let zone = vtimezone.getFirstSubcomponent(standardOrDaylight);
+        let zones = vtimezone.getAllSubcomponents(standardOrDaylight);
+
+        // sorting the timezones to get the lates timezone cause timezones have been changed multiple times in history
+        zones.sort((zone1, zone2)=>zone1.getFirstPropertyValue("dtstart")<zone2.getFirstPropertyValue("dtstart"));
+        let zone = zones[0];
 
         if (zone) {
             let obj = {};


### PR DESCRIPTION
Updated logic to retrieve all subcomponents of the VTIMEZONE instead of relying on the first one. The subcomponents are now sorted by DTSTART, and the latest applicable timezone rule is selected to avoid outdated offsets.

Tested with:
- Horde6 as server
- Mozilla Thunderbird v140.1.1
- TbSync Beta

Fixes #293 