### PR TITLE
Fix: Prioritize System Timezone during EAS Offset Guessing

### DIFF
--- a/content/includes/tools.js
+++ b/content/includes/tools.js
@@ -351,17 +351,29 @@ var tools = {
             let tzService = TbSync.lightning.cal.timezoneService;
 
             //cache timezones data from internal IANA data
+            // 1. Get the system's current timezone ID once before the loop
+            let systemTzid = TbSync.lightning.cal.timezoneService.defaultTimezone.tzid;
+
             for (let timezoneId of tzService.timezoneIds) {
                 let timezone = tzService.getTimezone(timezoneId);
                 let tzInfo = eas.tools.getTimezoneInfo(timezone);
 
-                eas.cachedTimezoneData.bothOffsets[tzInfo.std.offset + ":" + tzInfo.dst.offset] = timezone;
-                eas.cachedTimezoneData.stdOffset[tzInfo.std.offset] = timezone;
+                let offsetKey = tzInfo.std.offset + ":" + tzInfo.dst.offset;
+                let stdKey = tzInfo.std.offset;
 
+                // 2. Only overwrite the cache if the slot is empty
+                // OR if this specific timezone matches the System Timezone.
+                if (!eas.cachedTimezoneData.bothOffsets[offsetKey] || timezoneId === systemTzid) {
+                    eas.cachedTimezoneData.bothOffsets[offsetKey] = timezone;
+                }
+
+                if (!eas.cachedTimezoneData.stdOffset[stdKey] || timezoneId === systemTzid) {
+                    eas.cachedTimezoneData.stdOffset[stdKey] = timezone;
+                }
+
+                // Keep the rest of the original assignments
                 eas.cachedTimezoneData.abbreviations[tzInfo.std.abbreviation] = timezoneId;
                 eas.cachedTimezoneData.iana[timezoneId] = tzInfo;
-
-                //TbSync.dump("TZ ("+ tzInfo.std.id + " :: " + tzInfo.dst.id +  " :: " + tzInfo.std.displayname + " :: " + tzInfo.dst.displayname + " :: " + tzInfo.std.offset + " :: " + tzInfo.dst.offset + ")", tzService.getTimezone(id));
             }
 
             //make sure, that UTC timezone is there

--- a/manifest.json
+++ b/manifest.json
@@ -3,12 +3,12 @@
     "gecko": {
       "id": "eas4tbsync@jobisoft.de",
       "strict_min_version": "136.0",
-      "strict_max_version": "140.*"
+      "strict_max_version": "147.*"
     }
   },
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "4.17",
+  "version": "4.17.1",
   "author": "John Bieling",
   "homepage_url": "https://github.com/jobisoft/EAS-4-TbSync/",
   "default_locale": "en-US",


### PR DESCRIPTION
This PR resolves a synchronization issue where the Exchange ActiveSync (EAS) provider incorrectly maps timezones for regions that share the same UTC offset but have different Daylight Saving Time (DST) rules (e.g., Africa/Johannesburg vs. Europe/Kiev).

The Issue

In the current implementation of guessTimezoneByStdDstOffset, the timezone cache is built using a loop that overwrites entries as it iterates. Because multiple regions share the same UTC+2 offset, the last one processed in the loop "wins" the cache slot.

For users in South Africa, this resulted in the calendar choosing "Europe/Kiev." While the offset is identical today, it causes a 1-hour synchronization shift starting March 30th when Kiev enters DST and South Africa does not.

The Fix

I collaborated with Gemini (Google’s AI) to trace this "blind overwrite" bug and develop a more robust caching logic. Instead of a simple iteration, the loop now:

1. Initializes the cache only if the slot is empty (First-In-Wins).
2. Prioritizes the System Timezone: If the timezone being processed matches the user's actual defaultTimezone.tzid, it is granted priority to overwrite the slot.

This ensures that if a user lives in a specific UTC offset, the provider will always prefer their local region's DST rules over a "guessed" region with the same offset.