### PR TITLE
fix: do not add alarm when Reminder element has no value

### DIFF
--- a/content/includes/calendarsync.js
+++ b/content/includes/calendarsync.js
@@ -3,7 +3,7 @@
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
 "use strict";
@@ -132,7 +132,8 @@ var Calendar = {
 
         //EAS Reminder
         item.clearAlarms();
-        if (data.Reminder && data.StartTime) {
+        const isValidReminder = typeof data.Reminder === "string" && data.Reminder !== "";
+        if (isValidReminder && data.StartTime) {
             let alarm = new CalAlarm();
             alarm.related = Components.interfaces.calIAlarm.ALARM_RELATED_START;
             alarm.offset = cal.createDuration();
@@ -141,7 +142,7 @@ var Calendar = {
             let offsecs = parseInt(data.Reminder);
             if (!isNaN(offsecs)) {
                 alarm.offset.inSeconds = (0 - offsecs * 60);
-            }    
+            }
 
             item.addAlarm(alarm);
 
@@ -158,7 +159,7 @@ var Calendar = {
         eas.sync.mapEasPropertyToThunderbird("Sensitivity", "CLASS", data, item);
 
         if (data.ResponseType) {
-            //store original EAS value 
+            //store original EAS value
             item.setProperty("X-EAS-ResponseType", eas.xmltools.checkString(data.ResponseType, "0")); //some server send empty ResponseType ???
         }
 
@@ -244,7 +245,7 @@ var Calendar = {
         let tbStatus = (data.BusyStatus && data.BusyStatus == "1" ? "TENTATIVE" : null);
 
         if (data.MeetingStatus) {
-            //store original EAS value 
+            //store original EAS value
             item.setProperty("X-EAS-MeetingStatus", data.MeetingStatus);
             //bitwise representation for Meeting, Received, Cancelled:
             let M = data.MeetingStatus & 0x1;
@@ -286,7 +287,7 @@ var Calendar = {
         let nowDate = new Date();
 
         /*
-         *  We do not use ghosting, that means, if we do not include a value in CHANGE, it is removed from the server. 
+         *  We do not use ghosting, that means, if we do not include a value in CHANGE, it is removed from the server.
          *  However, this does not seem to work on all fields. Furthermore, we need to include any (empty) container to blank its childs.
          */
 
@@ -326,9 +327,9 @@ var Calendar = {
             }
 
 
-            // for EAS 16.1 dont send TimeZone at all since we use UTC timestamps this should work.  
+            // for EAS 16.1 dont send TimeZone at all since we use UTC timestamps this should work.
             if (asversion != "16.1") {
-                // EAS 16 [MS-ASCAL] 2.2.2.1 
+                // EAS 16 [MS-ASCAL] 2.2.2.1
                 // if (asversion == "16.1" && item.startDate && item.startDate.isDate && item.endDate && item.endDate.isDate) {
                 // client MUST NOT send TimeZone
                 // } else {
@@ -365,7 +366,7 @@ var Calendar = {
             // not in EAS 16: [MS-ASCAL] 2.2.2.18
             wbxml.atag("DtStamp", item.stampTime ? eas.tools.getIsoUtcString(item.stampTime) : eas.tools.dateToBasicISOString(nowDate));
         }
-        
+
         //EndTime in UTC
         // EAS 16 [MS-ASCAL] 2.2.2.1 -> no time component
         if (asversion == "16.1" && item.startDate && item.startDate.isDate && item.endDate && item.endDate.isDate) {
@@ -373,12 +374,12 @@ var Calendar = {
         } else {
             wbxml.atag("EndTime", item.endDate ? eas.tools.getIsoUtcString(item.endDate) : eas.tools.dateToBasicISOString(nowDate));
         }
-        
+
         //Location
         if (asversion != "16.1") {
             // not in EAS 16: [MS-ASCAL] 2.2.2.27
             wbxml.atag("Location", (item.hasProperty("location")) ? item.getProperty("location") : "");
-        } else {    
+        } else {
             // EAS 16 MS-AIRS 2.2.2.28
             if (item.hasProperty("location")) {
                 wbxml.switchpage("AirSyncBase");
@@ -388,7 +389,7 @@ var Calendar = {
                 wbxml.switchpage(syncdata.type);
             }
         }
-        
+
         //EAS Reminder (TB getAlarms) - at least with zpush blanking by omitting works, horde does not work
         let alarms = item.getAlarms({});
         if (alarms.length > 0) {
@@ -415,7 +416,7 @@ var Calendar = {
         //StartTime in UTC
         // EAS 16 [MS-ASCAL] 2.2.2.1
         if (asversion == "16.1" && item.startDate && item.startDate.isDate && item.endDate && item.endDate.isDate) {
-            wbxml.atag("StartTime",eas.tools.getIsoUtcString(item.startDate,false,true,true)); 
+            wbxml.atag("StartTime",eas.tools.getIsoUtcString(item.startDate,false,true,true));
         } else {
             wbxml.atag("StartTime", item.startDate ? eas.tools.getIsoUtcString(item.startDate) : eas.tools.dateToBasicISOString(nowDate));
         }
@@ -430,7 +431,7 @@ var Calendar = {
             }
         } else {
             // EAS 16.1 MS-ASCAL 2.2.2.13 optional ClientUid
-            //for some reason when defined Exchange Online rejects many change requests ... oh well .. since it is optional lets skip it ... 
+            //for some reason when defined Exchange Online rejects many change requests ... oh well .. since it is optional lets skip it ...
             //wbxml.atag("ClientUid", item.id);
         }
         //IMPORTANT in EAS v16 it is no longer allowed to send a UID
@@ -480,7 +481,7 @@ var Calendar = {
                     wbxml.atag("Email", cal.email.removeMailTo(attendee.id));
                     wbxml.atag("Name", (attendee.commonName ? attendee.commonName : cal.email.removeMailTo(attendee.id).split("@")[0]));
                     if (asversion != "2.5") {
-                        //it's pointless to send AttendeeStatus, 
+                        //it's pointless to send AttendeeStatus,
                         // - if we are the owner of a meeting, TB does not have an option to actually set the attendee status (on behalf of an attendee) in the UI
                         // - if we are an attendee (of an invite) we cannot and should not set status of other attendees and or own status must be send through a MeetingResponse
                         // -> all changes of attendee status are send from the server to us, either via ResponseType or via AttendeeStatus
@@ -495,7 +496,7 @@ var Calendar = {
                 wbxml.ctag();
             } else {
                 if (asversion != "16.1") {
-                    wbxml.atag("Attendees"); 
+                    wbxml.atag("Attendees");
                 }
             }
         }


### PR DESCRIPTION
### Problem
When creating a calendar event in Microsoft Calendar without a reminder, the server sends an empty XML tag:

`<Reminder xmlns='Calendar'/>`

The XML-to-JSON parser serializes this empty tag as an empty object `{}`. In JavaScript, `{}` is truthy, so the existing guard condition:

`if (data.Reminder && data.StartTime) { ... }`

evaluates to true, causing alarm creation to proceed. Since `parseInt({}, 10)` returns `NaN` and the offset is never set, the alarm is registered with 0 seconds offset. This is resulting in a 0-minute reminder being added to events that were intentionally created without one.

### Fix
Add a typeof check to ensure data.Reminder is a non-empty string before creating the alarm

### Steps to Reproduce
- Create a calendar event in Microsoft Calendar without setting a reminder
- Sync the event to Thunderbird via TbSync
- Open the event in Thunderbird: A 0-minute reminder is shown despite none being set

### Expected Behavior
No reminder/alarm is created in Thunderbird when the server sends <Reminder/>.

### Actual Behavior
A 0-minute alarm is added to the event.