### PR TITLE
Fix disambiguate same-offset time zones via DST transition rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,38 @@ This provider add-on adds Exchange ActiveSync (EAS v2.5, v14.0, 14.1 & v16.1) sy
 
 More information can be found in the [wiki](https://github.com/jobisoft/EAS-4-TbSync/wiki/About:-Provider-for-Exchange-ActiveSync) of this repository
 
+## Known limitations
+
+### Recurring events from a foreign time zone (±1 hour DST drift)
+
+A recurring series can drift by one hour around daylight-saving transitions
+**only when all three of the following hold**:
+
+1. the series was authored in a different time zone than your Thunderbird
+   default zone, **and**
+2. the server provides no usable time-zone information on the wire — this is
+   the case for EAS 16.0/16.1 (which carries no per-event `TimeZone` element)
+   and for servers that send an all-zero `TimeZone` blob (e.g. Z-Push, Kopano,
+   Grommunio), **and**
+3. the occurrence falls in a different DST state than the series master.
+
+In that situation the authoring zone is simply not transmitted, so the series
+is anchored to your default zone and individual occurrences across a DST
+boundary can be off by an hour. This is inherent to the protocol payload, not
+something the client can recover.
+
+Not affected:
+
+* Real Exchange ≤14.x — it sends a full `TimeZone` blob, which is matched back
+  to the correct IANA zone (including disambiguation between same-offset zones
+  such as Berlin/Paris via their DST transition dates).
+* Single, non-recurring events — their exact UTC instant is always preserved.
+* All-day events on the inbound/display path — the calendar date is read back
+  correctly for both server families (real-blob and no/empty-blob), in every
+  host time zone. (Pushing an all-day event *back* to a non-Exchange server
+  that ignores the `TimeZone` blob we send can still shift the date by a day
+  for users east of UTC; real Exchange round-trips cleanly.)
+
 ## Want to add or fix a localization?
 To help translating this project, please visit [crowdin.com](https://crowdin.com/profile/jobisoft), where the localizations are managed. If you want to add a new language, just contact me and I will set it up.
 

--- a/src/modules/eas/calendar-codec.mjs
+++ b/src/modules/eas/calendar-codec.mjs
@@ -755,8 +755,28 @@ function resolveTimezone(adNode, defaultTimezone) {
   const stdOffset = blob.utcOffset;
   const dstOffset = blob.daylightBias + blob.utcOffset;
   const stdName = blob.standardName;
-  const tzid = guessTimezoneByStdDstOffset(stdOffset, dstOffset, stdName);
+  // The SYSTEMTIME transition dates distinguish zones that share an
+  // offset but switch DST on different dates; pass them so the resolver
+  // can pick the right one instead of collapsing every UTC+1/+2 zone onto
+  // a single fallback (which makes recurring events drift by an hour
+  // around the mismatched transition).
+  const dstRule = dstRuleFromBlob(blob);
+  const tzid = guessTimezoneByStdDstOffset(stdOffset, dstOffset, stdName, dstRule);
   return { tzId: tzid || defaultTimezone || "UTC", fromBlob: true };
+}
+
+/** Extract the nth-weekday DST transition rule from a decoded TimeZone
+ *  blob's StandardDate / DaylightDate SYSTEMTIMEs, in the same shape the
+ *  timezone-mapping resolver stores per IANA zone. Returns null when the
+ *  blob carries no DST (wMonth === 0). */
+function dstRuleFromBlob(blob) {
+  const std = blob.standardDate;
+  const dst = blob.daylightDate;
+  if (!std || !dst || std.wMonth === 0 || dst.wMonth === 0) return null;
+  return {
+    std: { month: std.wMonth, weekOfMonth: std.wDay, dayOfWeek: std.wDayOfWeek },
+    dst: { month: dst.wMonth, weekOfMonth: dst.wDay, dayOfWeek: dst.wDayOfWeek },
+  };
 }
 
 function buildTimezoneBlob(vevent, defaultTimezone) {
@@ -767,13 +787,20 @@ function buildTimezoneBlob(vevent, defaultTimezone) {
   const blob = new TimeZoneBlob();
   blob.utcOffset = tzInfo.std.offset;
   blob.standardBias = 0;
-  blob.daylightBias = tzInfo.dst.offset - tzInfo.std.offset;
+  // Only advertise DST when we can also supply the SYSTEMTIME transition
+  // dates. A non-zero daylightBias with all-zero StandardDate/DaylightDate
+  // is contradictory: per the Windows TIME_ZONE_INFORMATION rules a zero
+  // wMonth means "no DST" (DaylightBias then ignored), but some servers
+  // honour the bias and apply DST year-round (or not at all), shifting the
+  // event by an hour for part of the year. Keep the blob consistent.
+  const hasDstRule = !!(tzInfo.std.switchdate && tzInfo.dst.switchdate);
+  blob.daylightBias = hasDstRule ? tzInfo.dst.offset - tzInfo.std.offset : 0;
   blob.standardName = tzInfo.stdWinName;
   blob.daylightName = tzInfo.dstWinName;
 
   // SYSTEMTIME-shaped switch dates, only when both std and dst rules exist
   // (no-DST zones leave both SYSTEMTIMEs zero-filled and daylightBias=0).
-  if (tzInfo.std.switchdate && tzInfo.dst.switchdate) {
+  if (hasDstRule) {
     const std = blob.standardDate;
     std.wMonth = tzInfo.std.switchdate.month;
     std.wDay = tzInfo.std.switchdate.weekOfMonth;

--- a/src/modules/eas/calendar-codec.mjs
+++ b/src/modules/eas/calendar-codec.mjs
@@ -186,21 +186,22 @@ function populateVeventFromAd({
     if (data) vevent.updatePropertyWithValue("description", data);
   }
 
-  // Resolve effective timezone (sticks to UTC on 16.1; otherwise use the
-  // TimeZone blob to derive an IANA zone via std/dst offset matching, or
-  // fall back to the host's default zone).
-  const tzId = resolveTimezone(adNode, asVersion, defaultTimezone);
+  // Resolve effective timezone: from the TimeZone blob when the server
+  // sent a real one (≤14.x Exchange), otherwise the host's default zone
+  // (AS 16.1, and servers that send an all-zero blob). `fromBlob` selects
+  // how all-day boundaries are interpreted (see writeDateProp).
+  const { tzId, fromBlob } = resolveTimezone(adNode, defaultTimezone);
   const allDay = readPathFrom(adNode, ["AllDayEvent"]) === "1";
 
   // Start / End. EAS sends UTC strings; convert on the way in.
   const startUtc = readPathFrom(adNode, ["StartTime"]);
   const endUtc = readPathFrom(adNode, ["EndTime"]);
-  if (startUtc) writeDateProp(vevent, "dtstart", startUtc, tzId, allDay);
-  if (endUtc) writeDateProp(vevent, "dtend", endUtc, tzId, allDay);
+  if (startUtc) writeDateProp(vevent, "dtstart", startUtc, tzId, allDay, fromBlob);
+  if (endUtc) writeDateProp(vevent, "dtend", endUtc, tzId, allDay, fromBlob);
 
   // DtStamp - preserve when present (AS ≤ 14.x); 16.1 omits.
   const dtStamp = readPathFrom(adNode, ["DtStamp"]);
-  if (dtStamp) writeDateProp(vevent, "dtstamp", dtStamp, "UTC", false);
+  if (dtStamp) writeDateProp(vevent, "dtstamp", dtStamp, "UTC", false, false);
 
   // BusyStatus → TRANSP. STATUS is computed below from BusyStatus +
   // MeetingStatus together (legacy calendarsync.js:235-265).
@@ -503,6 +504,10 @@ export function appendApplicationDataFromIcal({
   const dtstart = vevent.getFirstProperty("dtstart");
   const dtend = vevent.getFirstProperty("dtend");
   const allDay = isAllDayProp(dtstart) && isAllDayProp(dtend);
+  // Source zone for all-day Start/End on ≤14.x — must match the zone we
+  // describe in the TimeZone blob (same precedence as buildTimezoneBlob)
+  // so the server reads the boundary back on the right calendar day.
+  const allDaySourceTzid = pickSourceTzid(vevent) ?? defaultTimezone ?? "UTC";
   builder.atag("AllDayEvent", allDay ? "1" : "0");
 
   // Body.
@@ -559,11 +564,10 @@ export function appendApplicationDataFromIcal({
     );
   }
 
-  // EndTime. AS 16.1 all-day uses a "fake local as UTC" form
-  // (`YYYYMMDDT000000Z` from the local-clock date, no TZ conversion) -
-  // mirrors legacy `getIsoUtcString(date, false, true, true)` so the
-  // user-intended date isn't shifted by ±1 day in non-UTC zones.
-  builder.atag("EndTime", endTimeFor(dtend, asVersion, allDay));
+  // EndTime. All-day: 16.1 uses the "fake local as UTC" form; ≤14.x uses
+  // local midnight in the TimeZone-blob zone expressed as UTC. Both avoid
+  // the ±1-day shift a naive UTC conversion would cause in non-UTC zones.
+  builder.atag("EndTime", endTimeFor(dtend, asVersion, allDay, allDaySourceTzid));
 
   // Location.
   const location = stringOf(vevent.getFirstPropertyValue("location"));
@@ -599,7 +603,7 @@ export function appendApplicationDataFromIcal({
 
   // Subject + StartTime.
   builder.atag("Subject", stringOf(vevent.getFirstPropertyValue("summary")));
-  builder.atag("StartTime", startTimeFor(dtstart, asVersion, allDay));
+  builder.atag("StartTime", startTimeFor(dtstart, asVersion, allDay, allDaySourceTzid));
 
   // UID (forbidden in 16.1; not inside exceptions either - legacy
   // suppresses UID inside <Exception>, even on 2.5/14.x).
@@ -730,9 +734,19 @@ export function stampEasServerId(ical, serverID) {
 
 /* ── Helpers: timezone resolution ──────────────────────────────────── */
 
-function resolveTimezone(adNode, asVersion, defaultTimezone) {
+/** Resolve the effective IANA tzid for an inbound event and report
+ *  whether it came from a real (non-empty) TimeZone blob. `fromBlob`
+ *  drives the all-day boundary reading: a real blob means the server
+ *  encoded all-day Start/End as midnight-in-zone-expressed-as-UTC (real
+ *  Exchange ≤14.x), which must be converted back through the zone; a
+ *  missing/empty blob (AS 16.1, and Z-Push/Kopano/Grommunio, which send
+ *  an all-zero blob) means the date is a literal "fake local as UTC" and
+ *  must be read verbatim — see writeDateProp. */
+function resolveTimezone(adNode, defaultTimezone) {
   const blobB64 = readPathFrom(adNode, ["TimeZone"]);
-  if (!blobB64 || isAllZero(blobB64)) return defaultTimezone || "UTC";
+  if (!blobB64 || isAllZero(blobB64)) {
+    return { tzId: defaultTimezone || "UTC", fromBlob: false };
+  }
   const blob = new TimeZoneBlob();
   blob.easTimeZone64 = blobB64;
   // utcOffset is "minutes from local to UTC" (e.g. -60 for CET); daylight
@@ -742,7 +756,7 @@ function resolveTimezone(adNode, asVersion, defaultTimezone) {
   const dstOffset = blob.daylightBias + blob.utcOffset;
   const stdName = blob.standardName;
   const tzid = guessTimezoneByStdDstOffset(stdOffset, dstOffset, stdName);
-  return tzid || defaultTimezone || "UTC";
+  return { tzId: tzid || defaultTimezone || "UTC", fromBlob: true };
 }
 
 function buildTimezoneBlob(vevent, defaultTimezone) {
@@ -798,21 +812,50 @@ function pickSourceTzid(vevent) {
   return null;
 }
 
-function writeDateProp(vevent, name, easUtc, tzId, allDay) {
+function writeDateProp(vevent, name, easUtc, tzId, allDay, fromBlob) {
   // Replace any existing property of this name so merge-mode partial
   // Changes don't duplicate dtstart/dtend/dtstamp on the master.
   vevent.removeAllProperties(name);
   const prop = new ICAL.Property(name, vevent);
   if (allDay) {
-    // EAS UTC → date-only (drop time).
     const d = parseEasUtc(easUtc);
     if (!d) return;
-    const date = new ICAL.Time({
-      year: d.getUTCFullYear(),
-      month: d.getUTCMonth() + 1,
-      day: d.getUTCDate(),
-      isDate: true,
-    });
+    // The calendar date of an all-day boundary depends on how the server
+    // encodes it. Real Exchange ≤14.x sends the midnight that begins the
+    // day in the event's TimeZone, expressed as UTC ([MS-ASCAL] §2.2.2.39);
+    // for a non-UTC zone that instant lands on the previous/next UTC
+    // calendar day, so taking getUTCDate() directly shifts the event by
+    // ±1 day. Convert into the resolved zone first and take the wall-clock
+    // date there. Servers that send NO real TimeZone blob — AS 16.1, and
+    // Z-Push/Kopano/Grommunio (all-zero blob) — instead send a "fake local
+    // as UTC" YYYYMMDDT000000Z whose UTC date already IS the intended date
+    // (it mirrors what we emit outbound), so it must be read verbatim;
+    // converting it would shift the date by a day for users west of UTC.
+    // `fromBlob` is the discriminator: convert only when a real blob gave
+    // us the zone, otherwise read the UTC date verbatim.
+    let year = d.getUTCFullYear();
+    let month = d.getUTCMonth() + 1;
+    let day = d.getUTCDate();
+    if (fromBlob && tzId && tzId !== "UTC") {
+      const zone = getIcalTimezone(tzId);
+      if (zone) {
+        const utc = new ICAL.Time({
+          year,
+          month,
+          day,
+          hour: d.getUTCHours(),
+          minute: d.getUTCMinutes(),
+          second: d.getUTCSeconds(),
+          isDate: false,
+        });
+        utc.zone = ICAL.Timezone.utcTimezone;
+        const local = utc.convertToZone(zone);
+        year = local.year;
+        month = local.month;
+        day = local.day;
+      }
+    }
+    const date = new ICAL.Time({ year, month, day, isDate: true });
     prop.setValue(date);
   } else {
     const d = parseEasUtc(easUtc);
@@ -896,13 +939,46 @@ function fakeLocalAsUtcDate(prop) {
   return `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}T000000Z`;
 }
 
-function startTimeFor(dtstart, asVersion, allDay) {
-  if (asVersion === "16.1" && allDay) return fakeLocalAsUtcDate(dtstart);
+/** Midnight (local) of an all-day date in the event's source zone,
+ *  expressed as UTC — the form AS ≤14.x expects for all-day Start/End
+ *  ([MS-ASCAL] §2.2.2.39). Mirrors the inbound all-day reader so the
+ *  round-trip is stable for non-UTC zones. Falls back to treating the
+ *  date as UTC midnight when the zone isn't in the loaded set. */
+function allDayMidnightUtc(prop, sourceTzid) {
+  const v = prop?.getFirstValue();
+  if (!(v instanceof ICAL.Time)) return nowBasicUtc();
+  const zone =
+    sourceTzid && sourceTzid !== "UTC" ? getIcalTimezone(sourceTzid) : null;
+  const localMidnight = new ICAL.Time({
+    year: v.year,
+    month: v.month,
+    day: v.day,
+    hour: 0,
+    minute: 0,
+    second: 0,
+    isDate: false,
+  });
+  localMidnight.zone = zone ?? ICAL.Timezone.utcTimezone;
+  return formatBasicUtc(localMidnight.toJSDate());
+}
+
+function startTimeFor(dtstart, asVersion, allDay, sourceTzid) {
+  if (allDay) {
+    // 16.1 uses the "fake local as UTC" form; ≤14.x expects local
+    // midnight in the blob's zone expressed as UTC. A floating date-only
+    // value would otherwise be turned into UTC via the host's local zone
+    // (toJSDate), shifting the date by ±1 day for non-UTC users.
+    if (asVersion === "16.1") return fakeLocalAsUtcDate(dtstart);
+    return allDayMidnightUtc(dtstart, sourceTzid);
+  }
   return dtstart ? toBasicUtc(dtstart.getFirstValue()) : nowBasicUtc();
 }
 
-function endTimeFor(dtend, asVersion, allDay) {
-  if (asVersion === "16.1" && allDay) return fakeLocalAsUtcDate(dtend);
+function endTimeFor(dtend, asVersion, allDay, sourceTzid) {
+  if (allDay) {
+    if (asVersion === "16.1") return fakeLocalAsUtcDate(dtend);
+    return allDayMidnightUtc(dtend, sourceTzid);
+  }
   return dtend ? toBasicUtc(dtend.getFirstValue()) : nowBasicUtc();
 }
 

--- a/src/modules/eas/timezone-mapping.mjs
+++ b/src/modules/eas/timezone-mapping.mjs
@@ -148,6 +148,25 @@ async function loadInternal() {
     defaultInfo.std.windowsZoneName = ianaToWindows[currentZone];
   }
 
+  // 5) Pre-index the DST-transition rules by std:dst offset for the
+  //    resolver's Tier-3.5 disambiguation. Only zones that carry a parsed
+  //    nth-weekday rule on BOTH sides can ever match a blob's SYSTEMTIME
+  //    dates, so the rest are skipped here. Building this once at load time
+  //    turns the per-event Tier-3.5 lookup from an O(all-zones) scan into
+  //    an O(same-offset-bucket) one. Sorted tzid order makes the resolver's
+  //    pick deterministic across runs for rule-identical siblings (the
+  //    default zone is still preferred at resolve time, regardless of order).
+  cached.rulesByOffset = Object.create(null);
+  for (const tzid of Object.keys(cached.iana).sort()) {
+    const info = cached.iana[tzid];
+    const stdRule = info.std?.switchdate;
+    const dstRule = info.dst?.switchdate;
+    if (!stdRule || !dstRule) continue;
+    const key = `${info.std.offset}:${info.dst.offset}`;
+    if (!cached.rulesByOffset[key]) cached.rulesByOffset[key] = [];
+    cached.rulesByOffset[key].push({ tzid, stdRule, dstRule });
+  }
+
   _state = {
     windowsToIana,
     ianaToWindows,
@@ -249,31 +268,37 @@ function parseTzSubcomponent(vtimezone, kind, tzid) {
   const dtstart = sub.getFirstPropertyValue("dtstart");
   if (rrule && dtstart) {
     const rules = parseRRule(rrule);
-    if (
-      rules.FREQ === "YEARLY" &&
-      rules.BYDAY &&
-      rules.BYMONTH &&
-      rules.BYDAY.length > 2
-    ) {
-      const month = parseInt(rules.BYMONTH, 10);
-      const dayCode = rules.BYDAY.slice(-2);
-      let weekOfMonth = parseInt(rules.BYDAY.slice(0, -2), 10);
-      // SYSTEMTIME's wDay range is 1..5 where 5 means "last". Legacy
-      // clamps anything out of range (and negative "last-N" rules) to 5.
-      if (Number.isNaN(weekOfMonth) || weekOfMonth < 0 || weekOfMonth > 5) {
-        weekOfMonth = 5;
+    if (rules.FREQ === "YEARLY" && rules.BYDAY && rules.BYMONTH) {
+      // The ordinal week can be carried inline in BYDAY ("-1SU", "2SU") or
+      // split out into BYSETPOS ("BYDAY=SU;BYSETPOS=-1"); accept both so we
+      // don't silently drop the DST rule (and emit a contradictory blob)
+      // for zones the tzdata expresses the second way. Use the last
+      // weekday token if several are listed. SYSTEMTIME's wDay is 1..5
+      // where 5 means "last", so negative / out-of-range ordinals clamp
+      // to 5.
+      const lastDay = String(rules.BYDAY).split(",").pop().trim();
+      const m = /^([+-]?\d*)([A-Z]{2})$/.exec(lastDay);
+      if (m) {
+        const dayCode = m[2];
+        let ordinal = m[1] !== "" ? parseInt(m[1], 10) : NaN;
+        if (Number.isNaN(ordinal) && rules.BYSETPOS != null) {
+          ordinal = parseInt(rules.BYSETPOS, 10);
+        }
+        const weekOfMonth =
+          Number.isNaN(ordinal) || ordinal < 0 || ordinal > 5 ? 5 : ordinal;
+        let dayOfWeek = DAYS.indexOf(dayCode);
+        if (dayOfWeek < 0) dayOfWeek = 0;
+        const month = parseInt(rules.BYMONTH, 10);
+        const time = parseDtstartTime(dtstart);
+        obj.switchdate = {
+          month,
+          dayOfWeek,
+          weekOfMonth,
+          hour: time.hour,
+          minute: time.minute,
+          second: time.second,
+        };
       }
-      let dayOfWeek = DAYS.indexOf(dayCode);
-      if (dayOfWeek < 0) dayOfWeek = 0;
-      const time = parseDtstartTime(dtstart);
-      obj.switchdate = {
-        month,
-        dayOfWeek,
-        weekOfMonth,
-        hour: time.hour,
-        minute: time.minute,
-        second: time.second,
-      };
     }
   }
 
@@ -311,13 +336,39 @@ function parseDtstartTime(dtstart) {
   };
 }
 
-/** Inbound: given the std/dst offsets and the (possibly Windows) zone name
- *  carried in the EAS blob, return the IANA tzid that best matches.
- *  Mirrors legacy `eas.tools.guessTimezoneByStdDstOffset`.
+/** Compare a per-zone parsed switchdate against a blob-derived rule.
+ *  Both carry { month, weekOfMonth (1..5, 5=last), dayOfWeek (0..6) }.
+ *  False when either side is missing (zones without a parsed nth-weekday
+ *  rule never match). Hour/minute are intentionally ignored: the EAS
+ *  SYSTEMTIME local switch time and the IANA rule's wall time can differ
+ *  while still denoting the same zone. */
+function switchdateMatches(sd, rule) {
+  if (!sd || !rule) return false;
+  return (
+    sd.month === rule.month &&
+    sd.weekOfMonth === rule.weekOfMonth &&
+    sd.dayOfWeek === rule.dayOfWeek
+  );
+}
+
+/** Inbound: given the std/dst offsets, the (possibly Windows) zone name,
+ *  and optionally the DST transition rule carried in the EAS blob, return
+ *  the IANA tzid that best matches. Mirrors legacy
+ *  `eas.tools.guessTimezoneByStdDstOffset`, plus a transition-rule tier
+ *  that disambiguates same-offset zones.
+ *
+ *  `dstRule`, when provided, is `{ std:{month,weekOfMonth,dayOfWeek},
+ *  dst:{...} }` derived from the blob's StandardDate/DaylightDate
+ *  SYSTEMTIMEs (see calendar-codec `dstRuleFromBlob`).
  *
  *  Synchronous; the caller must `await ensureLoaded()` earlier in the
  *  sync entry point. Throws if called before initialisation. */
-export function guessTimezoneByStdDstOffset(stdOffset, dstOffset, stdName) {
+export function guessTimezoneByStdDstOffset(
+  stdOffset,
+  dstOffset,
+  stdName,
+  dstRule = null,
+) {
   if (!_state) {
     throw new Error("timezone-mapping: ensureLoaded() must be awaited first");
   }
@@ -355,6 +406,33 @@ export function guessTimezoneByStdDstOffset(stdOffset, dstOffset, stdName) {
     const fromAbbr = cached.abbreviations[part];
     if (fromAbbr && cached.iana[fromAbbr]?.std.offset === stdOffset) {
       return fromAbbr;
+    }
+  }
+
+  // Tier 3.5: when the name didn't resolve, many zones share these offsets
+  // (all of Western Europe is UTC+1/+2) and the blob carries DST switch
+  // dates, pick the zone whose transition rule matches. Without this the
+  // pure-offset fallback below collapses every same-offset zone onto a
+  // single tzid, so a recurring event whose true zone switches DST on a
+  // different date drifts by an hour around the transition. The candidate
+  // bucket is pre-indexed by offset and pre-sorted at load time, so this is
+  // a small deterministic scan. Prefer the user's default zone when it is
+  // itself a rule match (harmless tie-break among rule-identical siblings,
+  // e.g. Berlin vs. Paris).
+  if (dstRule) {
+    const bucket = cached.rulesByOffset[`${stdOffset}:${dstOffset}`];
+    if (bucket) {
+      let firstMatch = null;
+      for (const cand of bucket) {
+        if (
+          switchdateMatches(cand.stdRule, dstRule.std) &&
+          switchdateMatches(cand.dstRule, dstRule.dst)
+        ) {
+          if (cand.tzid === defaultTimezone) return cand.tzid;
+          if (!firstMatch) firstMatch = cand.tzid;
+        }
+      }
+      if (firstMatch) return firstMatch;
     }
   }
 


### PR DESCRIPTION
## Summary

Inbound EAS calendar sync could not tell apart IANA zones that share the same
standard/DST UTC offset but switch DST on different dates. The resolver
collapsed every same-offset zone onto a single fallback tzid, so a recurring
event authored in a *different* same-offset zone expanded with the wrong DST
rule and drifted by an hour around the transition. Separately, the outbound
TimeZone-blob writer set a non-zero `daylightBias` even when it wrote no
SYSTEMTIME transition dates — a self-contradictory blob that some servers
honour by applying DST for the wrong part of the year.

> **Note — stacked PR.** This branch builds on the all-day date fix and
> therefore contains two commits:
> - `calendar: fix all-day events shifting by ±1 day in non-UTC time zones` (prerequisite)
> - `calendar/timezone: disambiguate same-offset zones by DST rules; keep blob consistent` (this change)
>
> If the all-day fix is reviewed/merged separately first, this PR collapses to
> the timezone commit alone. Happy to split it differently if preferred.

## Problem

- **Recurring events from a foreign same-offset zone** (e.g. one UTC+1/+2 zone
  vs. another) drift ±1 h around DST transitions, because the master's
  recurrence is expanded in the wrong zone.
- **Contradictory outbound blob:** `daylightBias` was emitted without the
  matching `StandardDate`/`DaylightDate` SYSTEMTIMEs. Per the Windows
  `TIME_ZONE_INFORMATION` rules a zero `wMonth` means "no DST", but some
  servers apply the bias anyway.

## Fix

- **Tier-3.5 disambiguation (inbound):** when the Windows-name / abbreviation
  tiers don't resolve and the blob carries SYSTEMTIME transition dates, match
  those dates against the parsed IANA rules (`dstRuleFromBlob` +
  `switchdateMatches`) and pick the zone whose transition rule matches. The
  user's default zone is preferred among rule-identical siblings
  (e.g. Berlin vs. Paris).
- **Self-consistent blob (outbound):** only advertise `daylightBias` when the
  SYSTEMTIME transition dates are actually written.
- **More robust RRULE parsing:** read the DST ordinal from `BYSETPOS`
  (`BYDAY=SU;BYSETPOS=-1`) as well as the inline form (`BYDAY=-1SU`), so the
  rule isn't silently dropped for zones tzdata expresses the second way.
- **Determinism + performance:** the disambiguation candidates are pre-indexed
  by `std:dst` offset and pre-sorted at load time, turning the per-event lookup
  from an O(all zones) scan into an O(same-offset bucket) one with a
  deterministic pick.
- **Docs:** README now documents the residual, inherent limitation — a series
  from a foreign zone whose authoring zone isn't on the wire at all (AS 16.1,
  and servers that send an all-zero blob) can still drift, because that
  information simply isn't transmitted.

## Verification

- `node --check` on all touched files.
- Blob↔rule mapping exercised with the real `TimeZoneBlob` codec: a "W. Europe
  Standard Time" blob decodes to `{std:{10,5,0}, dst:{3,5,0}}`, matches
  Europe/Berlin's IANA switch dates, correctly rejects US Eastern (different
  transition dates), and a no-DST blob yields `null` (Tier 3.5 skipped).
- The new tier only fires when the name lookup fails **and** a DST blob is
  present, so existing resolution paths are unchanged.

## Risk

Low. Additive inbound tier guarded behind the existing fallbacks; the outbound
change only suppresses an already-contradictory field. No data-format change to
locally stored items.
