### PR TITLE
Implement EAS MeetingResponse for invitation Accept/Decline/Tentative

### DIFF
--- a/src/modules/eas/calendar-codec.mjs
+++ b/src/modules/eas/calendar-codec.mjs
@@ -54,13 +54,41 @@ const SENSITIVITY_TO_CLASS = {
 };
 const CLASS_TO_SENSITIVITY = { PUBLIC: "0", PRIVATE: "2", CONFIDENTIAL: "3" };
 
-// EAS AttendeeStatus → iCal PARTSTAT.
+// EAS AttendeeStatus/ResponseType → iCal PARTSTAT. Per MS-ASCAL both
+// enumerations share 0/2/3/4/5 = Unknown/Tentative/Accepted/Declined/
+// NotResponded (ResponseType additionally has 1=Organizer, not relevant
+// here). 5 is NOT "accepted" - confirmed empirically: a freshly-sent,
+// completely unanswered invite arrives with ResponseType=5. Mapping it
+// to ACCEPTED made every brand-new invite look pre-accepted, which in
+// turn made detectInvitationResponse (calendar-codec.mjs) see no change
+// when the user actually clicked Accept, since "already ACCEPTED" ===
+// "now ACCEPTED" - silently skipping the MeetingResponse entirely.
 const ATTENDEESTATUS_TO_PARTSTAT = {
   0: "NEEDS-ACTION",
   2: "TENTATIVE",
   3: "ACCEPTED",
   4: "DECLINED",
-  5: "ACCEPTED",
+  5: "NEEDS-ACTION",
+};
+
+// iCal PARTSTAT → EAS ResponseType, for re-stamping X-EAS-RESPONSETYPE
+// after a MeetingResponse round-trip. Same numeric scale ResponseType
+// already shares with AttendeeStatus above (both 2/3/4 = Tentative/
+// Accepted/Declined) - kept as its own map since it's a write-direction
+// concern, not the read-direction ATTENDEESTATUS_TO_PARTSTAT.
+const PARTSTAT_TO_RESPONSETYPE = {
+  TENTATIVE: "2",
+  ACCEPTED: "3",
+  DECLINED: "4",
+};
+
+// iCal PARTSTAT → EAS MeetingResponse UserResponse. A *different* scale
+// from ResponseType/AttendeeStatus above - MS-ASCMD §2.2.3.166.3 defines
+// UserResponse as 1=Accept, 2=Tentative, 3=Decline.
+const PARTSTAT_TO_USERRESPONSE = {
+  ACCEPTED: 1,
+  TENTATIVE: 2,
+  DECLINED: 3,
 };
 
 /* ── Reader: ApplicationData → iCal VEVENT ─────────────────────────── */
@@ -724,6 +752,167 @@ export function stampEasServerId(ical, serverID) {
   if (!vevent) return ical;
   vevent.updatePropertyWithValue(X_EAS_SERVERID.toLowerCase(), serverID);
   return vcal.toString();
+}
+
+/* ── Invitation response (MeetingResponse) detection ────────────────── */
+
+/** Does this stored item represent a self-attendee status change that
+ *  should go out as a `MeetingResponse`, rather than a generic Sync
+ *  push? Compares the *live* self-attendee PARTSTAT against
+ *  `X-EAS-RESPONSETYPE` (the last value the server told us), on items
+ *  flagged `X-EAS-MEETINGSTATUS` bit 0x2 ("received from another
+ *  organizer" - i.e. the user is an attendee, not the organizer).
+ *
+ *  Returns `{ userResponseCode, newResponseType }` when the delta is a
+ *  real Accept/Tentative/Decline change, `null` otherwise (organizer's
+ *  own items, no status change, or a PARTSTAT MeetingResponse has no
+ *  code for, e.g. NEEDS-ACTION). Calendar-only; not called for Tasks. */
+export function detectInvitationResponse({ ical, userEmail }) {
+  if (!userEmail) return null;
+  const vevent = parseFirstVevent(ical);
+  if (!vevent) return null;
+
+  const meetingStatus =
+    parseInt(vevent.getFirstPropertyValue(X_EAS_MEETINGSTATUS.toLowerCase()), 10) ||
+    0;
+  if (!(meetingStatus & 0x2)) return null;
+
+  const userEmailLower = String(userEmail).toLowerCase();
+  const selfAttendee = vevent
+    .getAllProperties("attendee")
+    .find((a) => stripMailto(a.getFirstValue()).toLowerCase() === userEmailLower);
+  if (!selfAttendee) return null;
+  const currentPartstat = selfAttendee.getParameter("partstat") ?? "NEEDS-ACTION";
+
+  const lastResponseType = vevent.getFirstPropertyValue(
+    X_EAS_RESPONSETYPE.toLowerCase(),
+  );
+  const lastPartstat = lastResponseType
+    ? ATTENDEESTATUS_TO_PARTSTAT[lastResponseType] ?? "NEEDS-ACTION"
+    : "NEEDS-ACTION";
+  if (currentPartstat === lastPartstat) return null;
+
+  const userResponseCode = PARTSTAT_TO_USERRESPONSE[currentPartstat];
+  const newResponseType = PARTSTAT_TO_RESPONSETYPE[currentPartstat];
+  if (!userResponseCode || !newResponseType) return null;
+
+  return { userResponseCode, newResponseType };
+}
+
+/** Carry the self-attendee's PARTSTAT from `priorIcal` (a pre-existing
+ *  local item about to be overwritten) onto `builtIcal` (freshly built
+ *  from a server AD). Used when `applyAdd` (sync-runner.mjs) adopts an
+ *  item Thunderbird's itip engine already created: the AD reflects the
+ *  server's state as of the Add, which doesn't yet know about a
+ *  response the user already set locally, so without this the adopt
+ *  would silently revert an already-clicked Accept/Decline/Tentative
+ *  back to NEEDS-ACTION. Returns `builtIcal` unchanged if there's
+ *  nothing meaningful to carry over. */
+export function preserveSelfPartstat({ builtIcal, priorIcal, userEmail }) {
+  if (!userEmail) return builtIcal;
+  const prior = parseFirstVevent(priorIcal);
+  if (!prior) return builtIcal;
+  const userEmailLower = String(userEmail).toLowerCase();
+  const priorSelf = prior
+    .getAllProperties("attendee")
+    .find((a) => stripMailto(a.getFirstValue()).toLowerCase() === userEmailLower);
+  const priorPartstat = priorSelf?.getParameter("partstat");
+  if (!priorPartstat || priorPartstat === "NEEDS-ACTION") return builtIcal;
+
+  const vcal = parseVCalendar(builtIcal);
+  if (!vcal) return builtIcal;
+  const vevent = vcal.getFirstSubcomponent("vevent");
+  if (!vevent) return builtIcal;
+  const builtSelf = vevent
+    .getAllProperties("attendee")
+    .find((a) => stripMailto(a.getFirstValue()).toLowerCase() === userEmailLower);
+  if (!builtSelf) return builtIcal;
+  builtSelf.setParameter("partstat", priorPartstat);
+  return vcal.toString();
+}
+
+/** Re-stamp X-EAS-RESPONSETYPE after a successful MeetingResponse so the
+ *  next sync pass doesn't re-detect the same already-sent response. */
+export function stampInvitationResponse(ical, newResponseType) {
+  const vcal = parseVCalendar(ical);
+  if (!vcal) return ical;
+  const vevent = vcal.getFirstSubcomponent("vevent");
+  if (!vevent) return ical;
+  vevent.updatePropertyWithValue(
+    X_EAS_RESPONSETYPE.toLowerCase(),
+    newResponseType,
+  );
+  return vcal.toString();
+}
+
+/** Does `candidateIcal` (a brand-new, not-yet-EAS-known local item, i.e.
+ *  an `added_by_user` changelog entry) look like Thunderbird's itip
+ *  engine creating a *duplicate* of an already-synced received invite,
+ *  rather than a genuine new meeting the user is organizing?
+ *
+ *  Thunderbird's own itip Accept/Decline/Tentative can create a
+ *  brand-new local item - with none of our stamped X-EAS-* fields at
+ *  all - instead of editing the existing synced copy, whenever it
+ *  doesn't find a matching item to modify (e.g. Accept racing the EAS
+ *  pull that would have supplied a matching id/UID - see `applyAdd` in
+ *  sync-runner.mjs). Since a fresh itip-created item has nothing of
+ *  ours to key off, this matches on subject + start + end against
+ *  `existingItems`' "received" items (`X-EAS-MEETINGSTATUS` bit 0x2).
+ *
+ *  Returns `{ existingItemId, userResponseCode, newResponseType }` on a
+ *  match with a real Accept/Tentative/Decline in `candidateIcal`, or
+ *  `null` (no match, or no self-attendee/real response in the
+ *  candidate - i.e. it really is just a new meeting being created). */
+export function matchInvitationResponse({
+  candidateIcal,
+  existingItems,
+  userEmail,
+}) {
+  if (!userEmail) return null;
+  const candidate = parseFirstVevent(candidateIcal);
+  if (!candidate) return null;
+
+  const userEmailLower = String(userEmail).toLowerCase();
+  const selfAttendee = candidate
+    .getAllProperties("attendee")
+    .find((a) => stripMailto(a.getFirstValue()).toLowerCase() === userEmailLower);
+  if (!selfAttendee) return null;
+  const partstat = selfAttendee.getParameter("partstat") ?? "NEEDS-ACTION";
+  const userResponseCode = PARTSTAT_TO_USERRESPONSE[partstat];
+  const newResponseType = PARTSTAT_TO_RESPONSETYPE[partstat];
+  if (!userResponseCode || !newResponseType) return null;
+
+  const summary = stringOf(candidate.getFirstPropertyValue("summary"));
+  const startKey = unixTimeKey(candidate.getFirstPropertyValue("dtstart"));
+  const endKey = unixTimeKey(candidate.getFirstPropertyValue("dtend"));
+  if (!summary || startKey == null || endKey == null) return null;
+
+  for (const existing of existingItems) {
+    const vevent = parseFirstVevent(existing.blob);
+    if (!vevent) continue;
+    const meetingStatus =
+      parseInt(
+        vevent.getFirstPropertyValue(X_EAS_MEETINGSTATUS.toLowerCase()),
+        10,
+      ) || 0;
+    if (!(meetingStatus & 0x2)) continue;
+    if (stringOf(vevent.getFirstPropertyValue("summary")) !== summary) continue;
+    if (unixTimeKey(vevent.getFirstPropertyValue("dtstart")) !== startKey)
+      continue;
+    if (unixTimeKey(vevent.getFirstPropertyValue("dtend")) !== endKey)
+      continue;
+    return { existingItemId: existing.id, userResponseCode, newResponseType };
+  }
+  return null;
+}
+
+function unixTimeKey(icalTime) {
+  if (!icalTime) return null;
+  try {
+    return icalTime.toUnixTime();
+  } catch {
+    return null;
+  }
 }
 
 /* ── Helpers: timezone resolution ──────────────────────────────────── */

--- a/src/modules/eas/calendar-sync.mjs
+++ b/src/modules/eas/calendar-sync.mjs
@@ -66,6 +66,12 @@ function makeCodec(modCodec) {
     applyInstanceChange: modCodec.applyInstanceChange,
     applyInstanceDelete: modCodec.applyInstanceDelete,
     appendInstanceChanges: modCodec.appendInstanceChanges,
+    // Optional invitation-response detection (calendar only). Undefined
+    // for the Tasks codec, so the runner's `?.()` call is a no-op there.
+    detectInvitationResponse: modCodec.detectInvitationResponse,
+    stampInvitationResponse: modCodec.stampInvitationResponse,
+    matchInvitationResponse: modCodec.matchInvitationResponse,
+    preserveSelfPartstat: modCodec.preserveSelfPartstat,
   };
 }
 

--- a/src/modules/eas/meeting-response.mjs
+++ b/src/modules/eas/meeting-response.mjs
@@ -1,0 +1,81 @@
+/**
+ * EAS MeetingResponse — tells the server the user Accepted / Tentatively
+ * accepted / Declined a meeting invite, by referencing the existing
+ * Calendar-collection item ([MS-ASCMD] §2.2.2.10 / §3.1.5.5).
+ *
+ * This is the protocol-correct replacement for pushing the itip-driven
+ * self-attendee PARTSTAT edit back as a plain `Sync <Change>`: the server
+ * updates the organizer's copy and notifies attendees itself, so the
+ * client must not *also* push a generic item edit for the same change
+ * (see `sync-runner.mjs`'s `detectInvitationResponse` gate).
+ *
+ * Wire shape:
+ *
+ *   <MeetingResponse>
+ *     <Request>
+ *       <UserResponse>1|2|3</UserResponse>
+ *       <airsync:CollectionId>…</airsync:CollectionId>
+ *       <airsync:RequestId>…</airsync:RequestId>
+ *     </Request>
+ *   </MeetingResponse>
+ *
+ * Response: `<MeetingResponse><Result><RequestId/><Status/>
+ * [<CalendarId/>]</Result></MeetingResponse>`. `CalendarId` is only present
+ * when the server created/moved an item into the Calendar folder as a
+ * result of the response; the caller's next regular pull sync reconciles
+ * that, so it's surfaced but not acted on here.
+ */
+
+import { createWBXML } from "../wbxml.mjs";
+import { easRequest } from "../network.mjs";
+import { readPathFrom } from "./wbxml-helpers.mjs";
+
+function buildBody({ collectionId, serverID, userResponse }) {
+  const w = createWBXML();
+  w.switchpage("MeetingResponse");
+  w.otag("MeetingResponse");
+  w.otag("Request");
+  w.atag("UserResponse", String(userResponse));
+  // CollectionId/RequestId are native tokens of the MeetingResponse
+  // codepage itself (0x06/0x08) - distinct from AirSync's own
+  // CollectionId (0x12) and from RequestId, which AirSync doesn't
+  // define at all. No switchpage needed/wanted here.
+  w.atag("CollectionId", collectionId);
+  w.atag("RequestId", serverID);
+  w.ctag();
+  w.ctag();
+  return w.getBytes();
+}
+
+/** Send a MeetingResponse for a single item. Returns `{ status, calendarId }`
+ *  on any response with a `<Result>` element (caller checks `status === "1"`
+ *  for success), or `null` on a network/transport failure or a malformed
+ *  response with no `<Result>`. Callers gate on
+ *  `easCommandLikelyAvailable(account, "MeetingResponse")` before calling. */
+export async function sendMeetingResponse({
+  account,
+  asVersion,
+  collectionId,
+  serverID,
+  userResponse,
+}) {
+  if (!collectionId || !serverID || !userResponse) return null;
+  let resp;
+  try {
+    resp = await easRequest({
+      account,
+      command: "MeetingResponse",
+      body: buildBody({ collectionId, serverID, userResponse }),
+      asVersion,
+    });
+  } catch {
+    return null;
+  }
+  if (!resp?.doc) return null;
+
+  const resultNode = resp.doc.getElementsByTagName("Result")[0];
+  if (!resultNode) return null;
+  const status = readPathFrom(resultNode, ["Status"]);
+  const calendarId = readPathFrom(resultNode, ["CalendarId"]);
+  return { status, calendarId };
+}

--- a/src/modules/eas/sync-runner.mjs
+++ b/src/modules/eas/sync-runner.mjs
@@ -43,6 +43,7 @@ import { createWBXML } from "../wbxml.mjs";
 import { readPath, readPathFrom } from "./wbxml-helpers.mjs";
 import { runGetItemEstimate } from "./get-item-estimate.mjs";
 import { fetchServerItem } from "./item-operations.mjs";
+import { sendMeetingResponse } from "./meeting-response.mjs";
 import { easCommandLikelyAvailable } from "./allowed-commands.mjs";
 import {
   ok,
@@ -716,6 +717,16 @@ async function pushPhase(ctx, userEdits) {
     if (!slice.length) break;
 
     const built = await buildPushBatch(ctx, slice);
+
+    if (built.invitationResponses.length) {
+      const anySent = await sendInvitationResponses(
+        ctx,
+        built.invitationResponses,
+        failedItems,
+      );
+      if (anySent) changedAnything = true;
+    }
+
     if (!built.adds.length && !built.mods.length && !built.dels.length) {
       itemsDone += slice.length;
       reportProgress(ctx, itemsDone, itemsTotal);
@@ -871,10 +882,79 @@ async function buildPushBatch(ctx, slice) {
   const adds = [];
   const mods = [];
   const dels = [];
+  const invitationResponses = [];
+  // Lazily fetched, calendar-only: the folder's already-synced items, used
+  // to recognise an `added_by_user` entry that is actually Thunderbird's
+  // itip engine creating a duplicate of an existing received invite (see
+  // matchInvitationResponse's doc comment). Fetched at most once per
+  // batch, only if a Calendar entry needs it.
+  let syncedItemsForMatch = null;
+
   for (const entry of slice) {
     if (entry.status === "added_by_user") {
       const it = await ctx.store.get(entry.itemId);
       if (!it?.blob) continue;
+
+      // An item that already carries our own X-EAS-SERVERID is, by
+      // definition, already EAS-tracked - a genuinely new user-created
+      // item can never have one yet. An `added_by_user` entry for such
+      // an item can only be a stale changelog artifact (e.g. a race
+      // between applyAdd adopting a pre-existing Thunderbird-created
+      // item - see the UID-collision handling there - and the host's own
+      // calendar observer, which can still fire after that adopt writes
+      // to the item). Pushing it as a fresh Add would create a
+      // duplicate meeting server-side even though nothing is actually
+      // new; drop the stale entry instead. This check doesn't depend on
+      // timing at all, unlike trying to clear the changelog entry
+      // proactively during the pull.
+      const alreadyTrackedServerId =
+        ctx.itemKind.codec.readEasServerIdFromBlob(it.blob);
+      if (alreadyTrackedServerId) {
+        ctx.provider.reportEventLog({
+          level: "warning",
+          accountId: ctx.accountId,
+          folderId: ctx.folderId,
+          message: `[${ctx.itemKind.changelogKind}-sync] dropped stale added_by_user entry for itemId=${entry.itemId}: already EAS-tracked (serverID=${alreadyTrackedServerId})`,
+        });
+        await ctx.provider.changelogRemove({
+          accountId: ctx.accountId,
+          folderId: ctx.folderId,
+          parentId: entry.parentId,
+          itemId: entry.itemId,
+        });
+        continue;
+      }
+
+      const matcher = ctx.itemKind.codec.matchInvitationResponse;
+      if (matcher) {
+        if (syncedItemsForMatch === null) {
+          const all = await ctx.store.list();
+          syncedItemsForMatch = all.filter((si) => si.id !== entry.itemId);
+        }
+        const match = matcher({
+          candidateIcal: it.blob,
+          existingItems: syncedItemsForMatch,
+          userEmail: ctx.account?.custom?.user,
+        });
+        if (match && easCommandLikelyAvailable(ctx.account, "MeetingResponse")) {
+          const existingIt = await ctx.store.get(match.existingItemId);
+          const serverID = existingIt?.blob
+            ? ctx.itemKind.codec.readEasServerIdFromBlob(existingIt.blob)
+            : null;
+          if (serverID) {
+            invitationResponses.push({
+              entry,
+              serverID,
+              item: it,
+              userResponseCode: match.userResponseCode,
+              newResponseType: match.newResponseType,
+              existingItemId: match.existingItemId,
+            });
+            continue;
+          }
+        }
+      }
+
       const clientId = `c-${Date.now().toString(36)}-${adds.length}`;
       adds.push({ entry, clientId, item: it });
     } else if (entry.status === "modified_by_user") {
@@ -884,6 +964,23 @@ async function buildPushBatch(ctx, slice) {
         ctx.itemKind.codec.readEasServerIdFromBlob(it.blob) ??
         findServerIdByUid(ctx, entry.itemId);
       if (!serverID) continue;
+      // An itip Accept/Decline/Tentative just flips the self-attendee's
+      // PARTSTAT on an otherwise-unrelated received invite - that's not
+      // a generic edit, it's an RSVP, and must go out as a dedicated
+      // MeetingResponse (see calendar-codec.mjs's detectInvitationResponse
+      // doc comment for why this can be detected from data alone, no UI
+      // hook needed). Only reroute when the server actually advertises
+      // the command; otherwise fall through to the old generic-push
+      // behaviour rather than silently dropping the user's response.
+      const invitation =
+        ctx.itemKind.codec.detectInvitationResponse?.({
+          ical: it.blob,
+          userEmail: ctx.account?.custom?.user,
+        }) ?? null;
+      if (invitation && easCommandLikelyAvailable(ctx.account, "MeetingResponse")) {
+        invitationResponses.push({ entry, serverID, item: it, ...invitation });
+        continue;
+      }
       mods.push({ entry, serverID, item: it });
     } else if (entry.status === "deleted_by_user") {
       const serverID = findServerIdByUid(ctx, entry.itemId);
@@ -916,7 +1013,85 @@ async function buildPushBatch(ctx, slice) {
       dels.push({ entry, serverID });
     }
   }
-  return { adds, mods, dels };
+  return { adds, mods, dels, invitationResponses };
+}
+
+/* ── Invitation responses (MeetingResponse) ──────────────────────────
+ *
+ * Each entry is sent as its own MeetingResponse command - a different
+ * EAS command from Sync, so these go out ahead of (and separately
+ * from) the batch's `sendSync` call. Success clears the changelog entry
+ * and re-stamps X-EAS-RESPONSETYPE locally so the next sync pass doesn't
+ * re-detect the same already-sent response; failure adds the item to
+ * `failedItems`, reusing pushPhase's existing tail-restage retry path -
+ * no separate retry plumbing needed. */
+
+async function sendInvitationResponses(ctx, invitationResponses, failedItems) {
+  let anySent = false;
+  for (const inv of invitationResponses) {
+    let result = null;
+    try {
+      result = await sendMeetingResponse({
+        account: ctx.account,
+        asVersion: ctx.asVersion,
+        collectionId: ctx.collectionId,
+        serverID: inv.serverID,
+        userResponse: inv.userResponseCode,
+      });
+    } catch (err) {
+      ctx.provider.reportEventLog({
+        level: "warning",
+        accountId: ctx.accountId,
+        folderId: ctx.folderId,
+        message: `[${ctx.itemKind.changelogKind}-sync] MeetingResponse threw for itemId=${inv.entry.itemId}: ${err?.message ?? String(err)}`,
+      });
+    }
+    if (!result || result.status !== STATUS_OK) {
+      failedItems.add(inv.entry.itemId);
+      ctx.provider.reportEventLog({
+        level: "warning",
+        accountId: ctx.accountId,
+        folderId: ctx.folderId,
+        message: `[${ctx.itemKind.changelogKind}-sync] MeetingResponse failed for itemId=${inv.entry.itemId} (status=${result?.status ?? "none"})`,
+      });
+      continue;
+    }
+    // `existingItemId` means this came from the added_by_user duplicate
+    // path (matchInvitationResponse): `inv.item` is a stray duplicate
+    // Thunderbird's itip engine created, not the real synced item, so
+    // the response gets stamped onto the *existing* item instead. The
+    // duplicate is deliberately left alone rather than auto-deleted - a
+    // content-based match isn't a guaranteed-unique key, so this only
+    // clears its changelog entry (stopping the repeated push attempts)
+    // and leaves cleanup to the user, called out in the log below.
+    const targetItemId = inv.existingItemId ?? inv.item.id;
+    const targetItem = inv.existingItemId
+      ? await ctx.store.get(inv.existingItemId)
+      : inv.item;
+    if (targetItem?.blob) {
+      const stamped = ctx.itemKind.codec.stampInvitationResponse(
+        targetItem.blob,
+        inv.newResponseType,
+      );
+      await ctx.store.update(targetItemId, stamped);
+    }
+    await ctx.provider.changelogRemove({
+      accountId: ctx.accountId,
+      folderId: ctx.folderId,
+      parentId: inv.entry.parentId,
+      itemId: inv.entry.itemId,
+    });
+    if (inv.existingItemId) {
+      ctx.provider.reportEventLog({
+        level: "warning",
+        accountId: ctx.accountId,
+        folderId: ctx.folderId,
+        message: `[${ctx.itemKind.changelogKind}-sync] itemId=${inv.entry.itemId} looked like a duplicate Thunderbird created while responding to an existing invite (itemId=${inv.existingItemId}); sent MeetingResponse using the existing item and dropped the duplicate's push. The duplicate local copy was left in place - delete it manually if it's still showing in your calendar.`,
+      });
+    }
+    anySent = true;
+  }
+  return anySent;
 }
 
 /* ── Apply responses to our push ──────────────────────────────────── */
@@ -1079,7 +1254,18 @@ async function applyAdd(ctx, addNode) {
   const existing = await findExistingByServerId(ctx, serverID);
   if (existing) return applyChangeFromAd(ctx, ad, existing);
 
-  const newId = crypto.randomUUID();
+  // Prefer the server's real UID (present on ≤14.x Add responses - see
+  // calendar-codec.mjs's applicationDataToIcal comment on Organizer/UID
+  // for the matching 16.1 caveat) as the local item's id/UID instead of
+  // a random one. Thunderbird's own itip engine matches invitation
+  // responses to an existing calendar item by UID across ALL calendars
+  // - if our stored copy carries the same UID the server/organizer used,
+  // Accepting an already-synced invite lands as a modifyItem TbSync can
+  // see and reroute (detectInvitationResponse), instead of a same-titled
+  // duplicate `addItem` TbSync can't tell apart from a real new meeting.
+  // Falls back to a random id when the AD has no UID (16.1, or Tasks -
+  // which have no UID field at all) - unchanged from prior behaviour.
+  const newId = readPathFrom(ad, ["UID"]) || crypto.randomUUID();
   const blob = await ctx.itemKind.codec.applicationDataToBlob({
     adNode: ad,
     serverID,
@@ -1100,6 +1286,100 @@ async function applyAdd(ctx, addNode) {
     status: "added_by_server",
     kind: ctx.itemKind.changelogKind,
   });
+
+  // Using the server's real UID above means a local item under that
+  // exact id can already exist here - Thunderbird's own itip engine may
+  // have created it (e.g. Accept clicked on an emailed invite before
+  // this pull ran; the mirror-image race is handled on the push side by
+  // matchInvitationResponse in buildPushBatch). Adopt it in place rather
+  // than risk a second `create` with a colliding id, which the native
+  // calendar may reject outright or clobber unpredictably. Trade-off:
+  // this overwrites whatever PARTSTAT the user already set via itip
+  // locally back to the server's (not-yet-updated) state - re-accepting
+  // after this sync will correctly route through MeetingResponse since
+  // the item is now EAS-tracked.
+  const preExisting = await ctx.store.get(newId);
+  if (preExisting) {
+    const userEmail = ctx.account?.custom?.user;
+    // Carry over any PARTSTAT the user already set via itip before this
+    // pull ran (e.g. clicked Accept on the emailed invite), so adopting
+    // the item doesn't silently revert it to NEEDS-ACTION.
+    const preservedBlob = ctx.itemKind.codec.preserveSelfPartstat
+      ? ctx.itemKind.codec.preserveSelfPartstat({
+          builtIcal: blob,
+          priorIcal: preExisting.blob,
+          userEmail,
+        })
+      : blob;
+    await ctx.store.update(newId, preservedBlob);
+    await verifyRoundTrip(ctx, newId, preservedBlob, "update");
+    upsertIndexMap(ctx, newId, serverID);
+    // The pre-existing item predates any EAS tracking, so it was almost
+    // certainly sitting in the changelog as its own `added_by_user` (or
+    // `modified_by_user`) entry from whatever local write created/touched
+    // it (e.g. the itip Accept itself). That entry now refers to stale
+    // pre-adoption content we just overwrote with the server's data - if
+    // left in place, the next push phase would send it out as a generic
+    // Add/Change (a self-match `matchInvitationResponse` can't catch,
+    // since this item is now the only copy, not a duplicate of another
+    // one). Clear it explicitly rather than let a "changelogMarkServerWrite
+    // + store.update" for a *different* itemId leave this one stale.
+    await ctx.provider.changelogRemove({
+      accountId: ctx.accountId,
+      folderId: ctx.folderId,
+      parentId: ctx.targetID,
+      itemId: newId,
+    });
+    // Since the stale changelog entry above is dropped rather than
+    // pushed, a PARTSTAT the user already set (just preserved onto
+    // preservedBlob) would otherwise never reach the server at all -
+    // send the MeetingResponse right here instead of waiting for a
+    // second Accept click to produce a fresh modified_by_user entry.
+    const invitation = ctx.itemKind.codec.detectInvitationResponse?.({
+      ical: preservedBlob,
+      userEmail,
+    });
+    if (invitation) {
+      const result = await sendMeetingResponse({
+        account: ctx.account,
+        asVersion: ctx.asVersion,
+        collectionId: ctx.collectionId,
+        serverID,
+        userResponse: invitation.userResponseCode,
+      }).catch((err) => {
+        ctx.provider.reportEventLog({
+          level: "warning",
+          accountId: ctx.accountId,
+          folderId: ctx.folderId,
+          message: `[${ctx.itemKind.changelogKind}-sync] MeetingResponse threw while adopting itemId=${newId}: ${err?.message ?? String(err)}`,
+        });
+        return null;
+      });
+      if (result?.status === STATUS_OK) {
+        const stamped = ctx.itemKind.codec.stampInvitationResponse(
+          preservedBlob,
+          invitation.newResponseType,
+        );
+        await ctx.store.update(newId, stamped);
+      } else {
+        ctx.provider.reportEventLog({
+          level: "warning",
+          accountId: ctx.accountId,
+          folderId: ctx.folderId,
+          message: `[${ctx.itemKind.changelogKind}-sync] MeetingResponse failed while adopting itemId=${newId} (status=${result?.status ?? "none"})`,
+        });
+      }
+    }
+    if (blobHasRecurrence(preservedBlob)) {
+      logRecurrence(
+        ctx,
+        `pull add (adopted pre-existing item): itemId=${newId}, serverID=${serverID}`,
+        { ical: preservedBlob },
+      );
+    }
+    return;
+  }
+
   const createdId = await ctx.store.create(newId, blob);
   if (createdId !== newId) {
     throw new Error(


### PR DESCRIPTION
## Summary

Accepting/declining a meeting invite never told Exchange anything via the protocol-correct channel: `MeetingResponse` was defined only as a WBXML codepage token (`modules/wbxml-codepages.mjs`), but never actually built or sent anywhere in the codebase.

Instead, when a user clicked Accept/Decline, Thunderbird's own itip engine would create/modify a local calendar item independent of TbSync (this is normal, expected Thunderbird behavior — it has no native concept of EAS's `MeetingResponse`). That local write gets picked up by the generic changelog and pushed back to Exchange as a plain `Sync <Add>`/`<Change>`, which Exchange interprets as the user creating a brand-new, self-organized meeting — duplicating the event and re-broadcasting invitations to every attendee. This has been reported repeatedly since 2018 without a working fix (#4, #10, #58, #66, #138 — where a contributor correctly diagnosed the missing `MeetingResponse` back in 2022 and it was never implemented — #203, #225, #320, #326).

Verified end-to-end against a real Exchange Online tenant (multiple attendees, multiple accept/decline/tentative round-trips) during development.

## What changed

- **`modules/eas/meeting-response.mjs`** (new): builds and sends the EAS `MeetingResponse` command ([MS-ASCMD] §2.2.2.10/§3.1.5.5), mirroring the existing single-purpose command modules (`get-item-estimate.mjs`, `item-operations.mjs`).
- **`modules/eas/calendar-codec.mjs`**:
  - `detectInvitationResponse` — recognizes an invitation response purely from item data (self-attendee PARTSTAT vs. the stashed `X-EAS-RESPONSETYPE`, gated on the `X-EAS-MEETINGSTATUS` "received" bit) on an already-tracked item. No UI hook or call-stack sniffing needed.
  - `matchInvitationResponse` — catches the case where Thunderbird creates a *duplicate* local item (with none of our `X-EAS-*` markers) instead of editing the already-synced copy, by matching subject/start/end against existing "received" items in the same folder.
  - `preserveSelfPartstat` — carries a PARTSTAT the user already set (via itip, before EAS ever synced the item) forward through adoption instead of silently reverting it to `NEEDS-ACTION`.
  - `stampInvitationResponse` — re-stamps `X-EAS-RESPONSETYPE` after a successful `MeetingResponse` so it isn't re-sent next sync.
  - Fixed `ATTENDEESTATUS_TO_PARTSTAT[5]` from `"ACCEPTED"` to `"NEEDS-ACTION"`. Per MS-ASCAL, `5` means "Not Responded" on both `AttendeeStatus` and `ResponseType` — confirmed empirically, a completely fresh, unanswered invite arrives with `ResponseType=5`. Mapping it to `ACCEPTED` made every untouched invite look pre-accepted (#4 "New Events are automatically confirmed without accepting them", #203 "Invitation automatically accepted"), which also masked real Accept transitions from `detectInvitationResponse`.
- **`modules/eas/calendar-sync.mjs`**: wires the above through as optional, calendar-only codec methods (same pattern already used for the 16.1 exception methods) — Tasks are unaffected.
- **`modules/eas/sync-runner.mjs`**:
  - `applyAdd` now uses the server's real `<UID>` (when present) as the new item's id instead of a random UUID, so Thunderbird's own itip matching can find the already-synced item on future accepts instead of creating a duplicate (#58 "Duplicate calendar entries").
  - When a pre-existing Thunderbird-created item already occupies that UID (the itip Accept raced the EAS pull), `applyAdd` adopts it in place — preserving any PARTSTAT already set, and sending `MeetingResponse` immediately as part of the adopt, so a single Accept click is enough (addresses #66 "Accepting Calendar Invites for Office 365 does not sync", #225 "meeting acceptance status not synchronised?").
  - `buildPushBatch` drops any `added_by_user` changelog entry whose item is already EAS-tracked (`X-EAS-SERVERID` present) rather than pushing it as a fresh `Add` — this check is timing-independent, unlike trying to clear the changelog entry proactively during the pull.
  - Detected invitation responses (from either the `modified_by_user` or the duplicate-`added_by_user` path) are routed through the new `MeetingResponse` command instead of a generic `Sync` push.

## Out of scope for this PR

- Per-occurrence (16.1 `InstanceId`) responses to a single instance of a recurring meeting — only master-level response is handled. The `MeetingResponse` codepage already reserves an `InstanceId` token for this follow-up.
- Batching multiple invitation responses into one `MeetingResponse` call (currently one request per response).

## Test plan

- [x] Accept/Decline/Tentative round-tripped against a real Exchange Online tenant with 3 accounts (organizer + 2 attendees), confirming: no duplicate event created, organizer stays correct, no spurious re-invites, `MeetingResponse` acknowledged with `Status=1`, and the response is visible in OWA and to other attendees.
- [x] Verified Tasks sync is unaffected (the new codec methods are calendar-only/optional).
- [ ] Recurring-meeting instance-level response (out of scope, noted above).

Fixes #320, #326, #138, #4, #203, #225. Related to #58, #66.