### PR TITLE
[AI] MeetingResponse incl. per-occurrence responses (InstanceId) - rebased #329 + follow-up

### DIFF
--- a/src/modules/eas/calendar-codec.mjs
+++ b/src/modules/eas/calendar-codec.mjs
@@ -54,13 +54,41 @@ const SENSITIVITY_TO_CLASS = {
 };
 const CLASS_TO_SENSITIVITY = { PUBLIC: "0", PRIVATE: "2", CONFIDENTIAL: "3" };
 
-// EAS AttendeeStatus → iCal PARTSTAT.
+// EAS AttendeeStatus/ResponseType → iCal PARTSTAT. Per MS-ASCAL both
+// enumerations share 0/2/3/4/5 = Unknown/Tentative/Accepted/Declined/
+// NotResponded (ResponseType additionally has 1=Organizer, not relevant
+// here). 5 is NOT "accepted" - confirmed empirically: a freshly-sent,
+// completely unanswered invite arrives with ResponseType=5. Mapping it
+// to ACCEPTED made every brand-new invite look pre-accepted, which in
+// turn made detectInvitationResponse (calendar-codec.mjs) see no change
+// when the user actually clicked Accept, since "already ACCEPTED" ===
+// "now ACCEPTED" - silently skipping the MeetingResponse entirely.
 const ATTENDEESTATUS_TO_PARTSTAT = {
   0: "NEEDS-ACTION",
   2: "TENTATIVE",
   3: "ACCEPTED",
   4: "DECLINED",
-  5: "ACCEPTED",
+  5: "NEEDS-ACTION",
+};
+
+// iCal PARTSTAT → EAS ResponseType, for re-stamping X-EAS-RESPONSETYPE
+// after a MeetingResponse round-trip. Same numeric scale ResponseType
+// already shares with AttendeeStatus above (both 2/3/4 = Tentative/
+// Accepted/Declined) - kept as its own map since it's a write-direction
+// concern, not the read-direction ATTENDEESTATUS_TO_PARTSTAT.
+const PARTSTAT_TO_RESPONSETYPE = {
+  TENTATIVE: "2",
+  ACCEPTED: "3",
+  DECLINED: "4",
+};
+
+// iCal PARTSTAT → EAS MeetingResponse UserResponse. A *different* scale
+// from ResponseType/AttendeeStatus above - MS-ASCMD §2.2.3.166.3 defines
+// UserResponse as 1=Accept, 2=Tentative, 3=Decline.
+const PARTSTAT_TO_USERRESPONSE = {
+  ACCEPTED: 1,
+  TENTATIVE: 2,
+  DECLINED: 3,
 };
 
 /* ── Reader: ApplicationData → iCal VEVENT ─────────────────────────── */
@@ -724,6 +752,167 @@ export function stampEasServerId(ical, serverID) {
   if (!vevent) return ical;
   vevent.updatePropertyWithValue(X_EAS_SERVERID.toLowerCase(), serverID);
   return vcal.toString();
+}
+
+/* ── Invitation response (MeetingResponse) detection ────────────────── */
+
+/** Does this stored item represent a self-attendee status change that
+ *  should go out as a `MeetingResponse`, rather than a generic Sync
+ *  push? Compares the *live* self-attendee PARTSTAT against
+ *  `X-EAS-RESPONSETYPE` (the last value the server told us), on items
+ *  flagged `X-EAS-MEETINGSTATUS` bit 0x2 ("received from another
+ *  organizer" - i.e. the user is an attendee, not the organizer).
+ *
+ *  Returns `{ userResponseCode, newResponseType }` when the delta is a
+ *  real Accept/Tentative/Decline change, `null` otherwise (organizer's
+ *  own items, no status change, or a PARTSTAT MeetingResponse has no
+ *  code for, e.g. NEEDS-ACTION). Calendar-only; not called for Tasks. */
+export function detectInvitationResponse({ ical, userEmail }) {
+  if (!userEmail) return null;
+  const vevent = parseFirstVevent(ical);
+  if (!vevent) return null;
+
+  const meetingStatus =
+    parseInt(vevent.getFirstPropertyValue(X_EAS_MEETINGSTATUS.toLowerCase()), 10) ||
+    0;
+  if (!(meetingStatus & 0x2)) return null;
+
+  const userEmailLower = String(userEmail).toLowerCase();
+  const selfAttendee = vevent
+    .getAllProperties("attendee")
+    .find((a) => stripMailto(a.getFirstValue()).toLowerCase() === userEmailLower);
+  if (!selfAttendee) return null;
+  const currentPartstat = selfAttendee.getParameter("partstat") ?? "NEEDS-ACTION";
+
+  const lastResponseType = vevent.getFirstPropertyValue(
+    X_EAS_RESPONSETYPE.toLowerCase(),
+  );
+  const lastPartstat = lastResponseType
+    ? ATTENDEESTATUS_TO_PARTSTAT[lastResponseType] ?? "NEEDS-ACTION"
+    : "NEEDS-ACTION";
+  if (currentPartstat === lastPartstat) return null;
+
+  const userResponseCode = PARTSTAT_TO_USERRESPONSE[currentPartstat];
+  const newResponseType = PARTSTAT_TO_RESPONSETYPE[currentPartstat];
+  if (!userResponseCode || !newResponseType) return null;
+
+  return { userResponseCode, newResponseType };
+}
+
+/** Carry the self-attendee's PARTSTAT from `priorIcal` (a pre-existing
+ *  local item about to be overwritten) onto `builtIcal` (freshly built
+ *  from a server AD). Used when `applyAdd` (sync-runner.mjs) adopts an
+ *  item Thunderbird's itip engine already created: the AD reflects the
+ *  server's state as of the Add, which doesn't yet know about a
+ *  response the user already set locally, so without this the adopt
+ *  would silently revert an already-clicked Accept/Decline/Tentative
+ *  back to NEEDS-ACTION. Returns `builtIcal` unchanged if there's
+ *  nothing meaningful to carry over. */
+export function preserveSelfPartstat({ builtIcal, priorIcal, userEmail }) {
+  if (!userEmail) return builtIcal;
+  const prior = parseFirstVevent(priorIcal);
+  if (!prior) return builtIcal;
+  const userEmailLower = String(userEmail).toLowerCase();
+  const priorSelf = prior
+    .getAllProperties("attendee")
+    .find((a) => stripMailto(a.getFirstValue()).toLowerCase() === userEmailLower);
+  const priorPartstat = priorSelf?.getParameter("partstat");
+  if (!priorPartstat || priorPartstat === "NEEDS-ACTION") return builtIcal;
+
+  const vcal = parseVCalendar(builtIcal);
+  if (!vcal) return builtIcal;
+  const vevent = vcal.getFirstSubcomponent("vevent");
+  if (!vevent) return builtIcal;
+  const builtSelf = vevent
+    .getAllProperties("attendee")
+    .find((a) => stripMailto(a.getFirstValue()).toLowerCase() === userEmailLower);
+  if (!builtSelf) return builtIcal;
+  builtSelf.setParameter("partstat", priorPartstat);
+  return vcal.toString();
+}
+
+/** Re-stamp X-EAS-RESPONSETYPE after a successful MeetingResponse so the
+ *  next sync pass doesn't re-detect the same already-sent response. */
+export function stampInvitationResponse(ical, newResponseType) {
+  const vcal = parseVCalendar(ical);
+  if (!vcal) return ical;
+  const vevent = vcal.getFirstSubcomponent("vevent");
+  if (!vevent) return ical;
+  vevent.updatePropertyWithValue(
+    X_EAS_RESPONSETYPE.toLowerCase(),
+    newResponseType,
+  );
+  return vcal.toString();
+}
+
+/** Does `candidateIcal` (a brand-new, not-yet-EAS-known local item, i.e.
+ *  an `added_by_user` changelog entry) look like Thunderbird's itip
+ *  engine creating a *duplicate* of an already-synced received invite,
+ *  rather than a genuine new meeting the user is organizing?
+ *
+ *  Thunderbird's own itip Accept/Decline/Tentative can create a
+ *  brand-new local item - with none of our stamped X-EAS-* fields at
+ *  all - instead of editing the existing synced copy, whenever it
+ *  doesn't find a matching item to modify (e.g. Accept racing the EAS
+ *  pull that would have supplied a matching id/UID - see `applyAdd` in
+ *  sync-runner.mjs). Since a fresh itip-created item has nothing of
+ *  ours to key off, this matches on subject + start + end against
+ *  `existingItems`' "received" items (`X-EAS-MEETINGSTATUS` bit 0x2).
+ *
+ *  Returns `{ existingItemId, userResponseCode, newResponseType }` on a
+ *  match with a real Accept/Tentative/Decline in `candidateIcal`, or
+ *  `null` (no match, or no self-attendee/real response in the
+ *  candidate - i.e. it really is just a new meeting being created). */
+export function matchInvitationResponse({
+  candidateIcal,
+  existingItems,
+  userEmail,
+}) {
+  if (!userEmail) return null;
+  const candidate = parseFirstVevent(candidateIcal);
+  if (!candidate) return null;
+
+  const userEmailLower = String(userEmail).toLowerCase();
+  const selfAttendee = candidate
+    .getAllProperties("attendee")
+    .find((a) => stripMailto(a.getFirstValue()).toLowerCase() === userEmailLower);
+  if (!selfAttendee) return null;
+  const partstat = selfAttendee.getParameter("partstat") ?? "NEEDS-ACTION";
+  const userResponseCode = PARTSTAT_TO_USERRESPONSE[partstat];
+  const newResponseType = PARTSTAT_TO_RESPONSETYPE[partstat];
+  if (!userResponseCode || !newResponseType) return null;
+
+  const summary = stringOf(candidate.getFirstPropertyValue("summary"));
+  const startKey = unixTimeKey(candidate.getFirstPropertyValue("dtstart"));
+  const endKey = unixTimeKey(candidate.getFirstPropertyValue("dtend"));
+  if (!summary || startKey == null || endKey == null) return null;
+
+  for (const existing of existingItems) {
+    const vevent = parseFirstVevent(existing.blob);
+    if (!vevent) continue;
+    const meetingStatus =
+      parseInt(
+        vevent.getFirstPropertyValue(X_EAS_MEETINGSTATUS.toLowerCase()),
+        10,
+      ) || 0;
+    if (!(meetingStatus & 0x2)) continue;
+    if (stringOf(vevent.getFirstPropertyValue("summary")) !== summary) continue;
+    if (unixTimeKey(vevent.getFirstPropertyValue("dtstart")) !== startKey)
+      continue;
+    if (unixTimeKey(vevent.getFirstPropertyValue("dtend")) !== endKey)
+      continue;
+    return { existingItemId: existing.id, userResponseCode, newResponseType };
+  }
+  return null;
+}
+
+function unixTimeKey(icalTime) {
+  if (!icalTime) return null;
+  try {
+    return icalTime.toUnixTime();
+  } catch {
+    return null;
+  }
 }
 
 /* ── Helpers: timezone resolution ──────────────────────────────────── */

--- a/src/modules/eas/calendar-codec.mjs
+++ b/src/modules/eas/calendar-codec.mjs
@@ -768,13 +768,61 @@ export function stampEasServerId(ical, serverID) {
  *  own items, no status change, or a PARTSTAT MeetingResponse has no
  *  code for, e.g. NEEDS-ACTION). Calendar-only; not called for Tasks. */
 export function detectInvitationResponse({ ical, userEmail }) {
-  if (!userEmail) return null;
-  const vevent = parseFirstVevent(ical);
-  if (!vevent) return null;
+  const vcal = parseVCalendar(ical);
+  if (!vcal) return null;
+  const master = pickMasterVevent(vcal);
+  if (!master) return null;
+  return compareSelfPartstat(master, userEmail);
+}
 
-  const meetingStatus =
-    parseInt(vevent.getFirstPropertyValue(X_EAS_MEETINGSTATUS.toLowerCase()), 10) ||
-    0;
+/** Every pending response on this item: the series-level one plus one per
+ *  overridden occurrence.
+ *
+ *  A whole recurring series is a single EAS item, so a changelog entry always
+ *  names the master. Thunderbird, however, records an Accept clicked on one
+ *  occurrence by creating an *exception* for it - which is what answering a
+ *  recurring invitation from the calendar view always does, not an edge case.
+ *  Looking only at the master therefore misses the response entirely and the
+ *  RSVP is silently lost, so every VEVENT carrying a RECURRENCE-ID is checked
+ *  too and answered with MeetingResponse's `InstanceId`.
+ *
+ *  Returns an array of `{ userResponseCode, newResponseType, instanceId }`,
+ *  where `instanceId` is `null` for the series-level response and otherwise
+ *  the occurrence's original start as a 24-character UTC timestamp (see
+ *  `instanceIdFromRecurrenceId`). Empty when nothing is a real
+ *  Accept/Tentative/Decline transition - the caller then treats the change as
+ *  an ordinary edit. */
+export function detectInvitationResponses({ ical, userEmail }) {
+  const vcal = parseVCalendar(ical);
+  if (!vcal) return [];
+
+  const out = [];
+  for (const vevent of vcal.getAllSubcomponents("vevent")) {
+    const response = compareSelfPartstat(vevent, userEmail);
+    if (!response) continue;
+    const recurrenceId = vevent.getFirstPropertyValue("recurrence-id");
+    response.instanceId = recurrenceId
+      ? instanceIdFromRecurrenceId(recurrenceId)
+      : null;
+    // An override we cannot address by InstanceId must not be answered as if
+    // it were the whole series, so drop it rather than guess.
+    if (recurrenceId && !response.instanceId) continue;
+    out.push(response);
+  }
+  return out;
+}
+
+/** The marker comparison for one VEVENT - master or override. Compares the
+ *  live self-attendee PARTSTAT against `X-EAS-RESPONSETYPE`, the status the
+ *  server last reported, on items flagged `X-EAS-MEETINGSTATUS` bit 0x2
+ *  ("received from another organizer"). Returns
+ *  `{ userResponseCode, newResponseType }` for a real transition, else null. */
+function compareSelfPartstat(vevent, userEmail) {
+  if (!userEmail || !vevent) return null;
+
+  // Overrides do not always carry their own MeetingStatus, so fall back to the
+  // master's - the "received" flag belongs to the meeting, not the occurrence.
+  const meetingStatus = meetingStatusFor(vevent);
   if (!(meetingStatus & 0x2)) return null;
 
   const userEmailLower = String(userEmail).toLowerCase();
@@ -797,6 +845,49 @@ export function detectInvitationResponse({ ical, userEmail }) {
   if (!userResponseCode || !newResponseType) return null;
 
   return { userResponseCode, newResponseType };
+}
+
+/** `X-EAS-MEETINGSTATUS` for this VEVENT, falling back to the master of the
+ *  same VCALENDAR when an override does not carry its own copy. */
+function meetingStatusFor(vevent) {
+  const own = parseInt(
+    vevent.getFirstPropertyValue(X_EAS_MEETINGSTATUS.toLowerCase()),
+    10,
+  );
+  if (!Number.isNaN(own)) return own;
+  const parent = vevent.parent;
+  if (!parent) return 0;
+  const master = pickMasterVevent(parent);
+  if (!master || master === vevent) return 0;
+  return (
+    parseInt(
+      master.getFirstPropertyValue(X_EAS_MEETINGSTATUS.toLowerCase()),
+      10,
+    ) || 0
+  );
+}
+
+/** RECURRENCE-ID → MeetingResponse `InstanceId`.
+ *
+ *  Beware: this is NOT the same format as the AirSyncBase `InstanceId` used
+ *  when pushing a 16.1 exception change, even though both are "a UTC timestamp
+ *  identifying an occurrence". MeetingResponseRequest.xsd restricts InstanceId
+ *  to exactly 24 characters, i.e. the extended form 2026-08-10T07:45:00.000Z,
+ *  while AirSyncBase uses the 16-character basic form 20260810T074500Z.
+ *  Sending the basic form makes Exchange reject the whole request with
+ *  MeetingResponse Status 2 ("invalid meeting request"), which is
+ *  indistinguishable from a genuinely stale meeting - so keep the two apart.
+ *
+ *  Returns null if the value cannot be turned into that exact shape. */
+function instanceIdFromRecurrenceId(recurrenceId) {
+  try {
+    const jsDate = recurrenceId.toJSDate?.();
+    if (!jsDate || Number.isNaN(jsDate.getTime())) return null;
+    const iso = jsDate.toISOString();
+    return iso.length === 24 ? iso : null;
+  } catch {
+    return null;
+  }
 }
 
 /** Carry the self-attendee's PARTSTAT from `priorIcal` (a pre-existing
@@ -833,16 +924,28 @@ export function preserveSelfPartstat({ builtIcal, priorIcal, userEmail }) {
 
 /** Re-stamp X-EAS-RESPONSETYPE after a successful MeetingResponse so the
  *  next sync pass doesn't re-detect the same already-sent response. */
-export function stampInvitationResponse(ical, newResponseType) {
+export function stampInvitationResponse(ical, newResponseType, instanceId = null) {
   const vcal = parseVCalendar(ical);
   if (!vcal) return ical;
-  const vevent = vcal.getFirstSubcomponent("vevent");
+  const vevent = instanceId
+    ? findVeventByInstanceId(vcal, instanceId)
+    : pickMasterVevent(vcal);
   if (!vevent) return ical;
   vevent.updatePropertyWithValue(
     X_EAS_RESPONSETYPE.toLowerCase(),
     newResponseType,
   );
   return vcal.toString();
+}
+
+/** Locate the override VEVENT whose RECURRENCE-ID matches an InstanceId
+ *  produced by `instanceIdFromRecurrenceId`. */
+function findVeventByInstanceId(vcal, instanceId) {
+  for (const vevent of vcal.getAllSubcomponents("vevent")) {
+    const rid = vevent.getFirstPropertyValue("recurrence-id");
+    if (rid && instanceIdFromRecurrenceId(rid) === instanceId) return vevent;
+  }
+  return null;
 }
 
 /** Does `candidateIcal` (a brand-new, not-yet-EAS-known local item, i.e.

--- a/src/modules/eas/calendar-sync.mjs
+++ b/src/modules/eas/calendar-sync.mjs
@@ -66,6 +66,12 @@ function makeCodec(modCodec) {
     applyInstanceChange: modCodec.applyInstanceChange,
     applyInstanceDelete: modCodec.applyInstanceDelete,
     appendInstanceChanges: modCodec.appendInstanceChanges,
+    // Optional invitation-response detection (calendar only). Undefined
+    // for the Tasks codec, so the runner's `?.()` call is a no-op there.
+    detectInvitationResponse: modCodec.detectInvitationResponse,
+    stampInvitationResponse: modCodec.stampInvitationResponse,
+    matchInvitationResponse: modCodec.matchInvitationResponse,
+    preserveSelfPartstat: modCodec.preserveSelfPartstat,
   };
 }
 

--- a/src/modules/eas/calendar-sync.mjs
+++ b/src/modules/eas/calendar-sync.mjs
@@ -69,6 +69,7 @@ function makeCodec(modCodec) {
     // Optional invitation-response detection (calendar only). Undefined
     // for the Tasks codec, so the runner's `?.()` call is a no-op there.
     detectInvitationResponse: modCodec.detectInvitationResponse,
+    detectInvitationResponses: modCodec.detectInvitationResponses,
     stampInvitationResponse: modCodec.stampInvitationResponse,
     matchInvitationResponse: modCodec.matchInvitationResponse,
     preserveSelfPartstat: modCodec.preserveSelfPartstat,

--- a/src/modules/eas/meeting-response.mjs
+++ b/src/modules/eas/meeting-response.mjs
@@ -1,0 +1,81 @@
+/**
+ * EAS MeetingResponse — tells the server the user Accepted / Tentatively
+ * accepted / Declined a meeting invite, by referencing the existing
+ * Calendar-collection item ([MS-ASCMD] §2.2.2.10 / §3.1.5.5).
+ *
+ * This is the protocol-correct replacement for pushing the itip-driven
+ * self-attendee PARTSTAT edit back as a plain `Sync <Change>`: the server
+ * updates the organizer's copy and notifies attendees itself, so the
+ * client must not *also* push a generic item edit for the same change
+ * (see `sync-runner.mjs`'s `detectInvitationResponse` gate).
+ *
+ * Wire shape:
+ *
+ *   <MeetingResponse>
+ *     <Request>
+ *       <UserResponse>1|2|3</UserResponse>
+ *       <airsync:CollectionId>…</airsync:CollectionId>
+ *       <airsync:RequestId>…</airsync:RequestId>
+ *     </Request>
+ *   </MeetingResponse>
+ *
+ * Response: `<MeetingResponse><Result><RequestId/><Status/>
+ * [<CalendarId/>]</Result></MeetingResponse>`. `CalendarId` is only present
+ * when the server created/moved an item into the Calendar folder as a
+ * result of the response; the caller's next regular pull sync reconciles
+ * that, so it's surfaced but not acted on here.
+ */
+
+import { createWBXML } from "../wbxml.mjs";
+import { easRequest } from "../network.mjs";
+import { readPathFrom } from "./wbxml-helpers.mjs";
+
+function buildBody({ collectionId, serverID, userResponse }) {
+  const w = createWBXML();
+  w.switchpage("MeetingResponse");
+  w.otag("MeetingResponse");
+  w.otag("Request");
+  w.atag("UserResponse", String(userResponse));
+  // CollectionId/RequestId are native tokens of the MeetingResponse
+  // codepage itself (0x06/0x08) - distinct from AirSync's own
+  // CollectionId (0x12) and from RequestId, which AirSync doesn't
+  // define at all. No switchpage needed/wanted here.
+  w.atag("CollectionId", collectionId);
+  w.atag("RequestId", serverID);
+  w.ctag();
+  w.ctag();
+  return w.getBytes();
+}
+
+/** Send a MeetingResponse for a single item. Returns `{ status, calendarId }`
+ *  on any response with a `<Result>` element (caller checks `status === "1"`
+ *  for success), or `null` on a network/transport failure or a malformed
+ *  response with no `<Result>`. Callers gate on
+ *  `easCommandLikelyAvailable(account, "MeetingResponse")` before calling. */
+export async function sendMeetingResponse({
+  account,
+  asVersion,
+  collectionId,
+  serverID,
+  userResponse,
+}) {
+  if (!collectionId || !serverID || !userResponse) return null;
+  let resp;
+  try {
+    resp = await easRequest({
+      account,
+      command: "MeetingResponse",
+      body: buildBody({ collectionId, serverID, userResponse }),
+      asVersion,
+    });
+  } catch {
+    return null;
+  }
+  if (!resp?.doc) return null;
+
+  const resultNode = resp.doc.getElementsByTagName("Result")[0];
+  if (!resultNode) return null;
+  const status = readPathFrom(resultNode, ["Status"]);
+  const calendarId = readPathFrom(resultNode, ["CalendarId"]);
+  return { status, calendarId };
+}

--- a/src/modules/eas/meeting-response.mjs
+++ b/src/modules/eas/meeting-response.mjs
@@ -16,6 +16,7 @@
  *       <UserResponse>1|2|3</UserResponse>
  *       <airsync:CollectionId>…</airsync:CollectionId>
  *       <airsync:RequestId>…</airsync:RequestId>
+ *       [<InstanceId>…</InstanceId>]
  *     </Request>
  *   </MeetingResponse>
  *
@@ -30,7 +31,7 @@ import { createWBXML } from "../wbxml.mjs";
 import { easRequest } from "../network.mjs";
 import { readPathFrom } from "./wbxml-helpers.mjs";
 
-function buildBody({ collectionId, serverID, userResponse }) {
+function buildBody({ collectionId, serverID, userResponse, instanceId }) {
   const w = createWBXML();
   w.switchpage("MeetingResponse");
   w.otag("MeetingResponse");
@@ -42,6 +43,10 @@ function buildBody({ collectionId, serverID, userResponse }) {
   // define at all. No switchpage needed/wanted here.
   w.atag("CollectionId", collectionId);
   w.atag("RequestId", serverID);
+  // A whole recurring series is one EAS item, so responding to a single
+  // occurrence names that instance rather than addressing a different item.
+  // InstanceId follows RequestId in the schema and is valid from 14.1 on.
+  if (instanceId) w.atag("InstanceId", instanceId);
   w.ctag();
   w.ctag();
   return w.getBytes();
@@ -58,14 +63,21 @@ export async function sendMeetingResponse({
   collectionId,
   serverID,
   userResponse,
+  instanceId = null,
 }) {
   if (!collectionId || !serverID || !userResponse) return null;
+  // MeetingResponseRequest.xsd restricts InstanceId to exactly 24 characters
+  // (the extended form 2026-08-10T07:45:00.000Z) - unlike the AirSyncBase
+  // InstanceId, which is the 16-character basic form. Getting it wrong is
+  // answered with Status 2, so refuse to send a malformed value rather than
+  // have the server reject the response as an invalid meeting.
+  if (instanceId && String(instanceId).length !== 24) return null;
   let resp;
   try {
     resp = await easRequest({
       account,
       command: "MeetingResponse",
-      body: buildBody({ collectionId, serverID, userResponse }),
+      body: buildBody({ collectionId, serverID, userResponse, instanceId }),
       asVersion,
     });
   } catch {

--- a/src/modules/eas/sync-runner.mjs
+++ b/src/modules/eas/sync-runner.mjs
@@ -951,9 +951,15 @@ async function buildPushBatch(ctx, slice) {
               entry,
               serverID,
               item: it,
-              userResponseCode: match.userResponseCode,
-              newResponseType: match.newResponseType,
               existingItemId: match.existingItemId,
+              // a duplicate created by itip always answers the whole series
+              responses: [
+                {
+                  userResponseCode: match.userResponseCode,
+                  newResponseType: match.newResponseType,
+                  instanceId: null,
+                },
+              ],
             });
             continue;
           }
@@ -972,18 +978,29 @@ async function buildPushBatch(ctx, slice) {
       // An itip Accept/Decline/Tentative just flips the self-attendee's
       // PARTSTAT on an otherwise-unrelated received invite - that's not
       // a generic edit, it's an RSVP, and must go out as a dedicated
-      // MeetingResponse (see calendar-codec.mjs's detectInvitationResponse
+      // MeetingResponse (see calendar-codec.mjs's detectInvitationResponses
       // doc comment for why this can be detected from data alone, no UI
-      // hook needed). Only reroute when the server actually advertises
-      // the command; otherwise fall through to the old generic-push
-      // behaviour rather than silently dropping the user's response.
-      const invitation =
-        ctx.itemKind.codec.detectInvitationResponse?.({
+      // hook needed). A recurring series is one EAS item, so this can yield
+      // several responses at once: the series plus any occurrence answered
+      // individually, each addressed by its own InstanceId. Only reroute when
+      // the server actually advertises the command; otherwise fall through to
+      // the old generic-push behaviour rather than silently dropping the
+      // user's response.
+      const detected =
+        ctx.itemKind.codec.detectInvitationResponses?.({
           ical: it.blob,
           userEmail: ctx.account?.custom?.user,
-        }) ?? null;
-      if (invitation && easCommandLikelyAvailable(ctx.account, "MeetingResponse")) {
-        invitationResponses.push({ entry, serverID, item: it, ...invitation });
+        }) ?? [];
+      if (
+        detected.length &&
+        easCommandLikelyAvailable(ctx.account, "MeetingResponse")
+      ) {
+        invitationResponses.push({
+          entry,
+          serverID,
+          item: it,
+          responses: detected,
+        });
         continue;
       }
       mods.push({ entry, serverID, item: it });
@@ -1034,52 +1051,73 @@ async function buildPushBatch(ctx, slice) {
 async function sendInvitationResponses(ctx, invitationResponses, failedItems) {
   let anySent = false;
   for (const inv of invitationResponses) {
-    let result = null;
-    try {
-      result = await sendMeetingResponse({
-        account: ctx.account,
-        asVersion: ctx.asVersion,
-        collectionId: ctx.collectionId,
-        serverID: inv.serverID,
-        userResponse: inv.userResponseCode,
-      });
-    } catch (err) {
-      ctx.provider.reportEventLog({
-        level: "warning",
-        accountId: ctx.accountId,
-        folderId: ctx.folderId,
-        message: `[${ctx.itemKind.changelogKind}-sync] MeetingResponse threw for itemId=${inv.entry.itemId}: ${err?.message ?? String(err)}`,
-      });
+    // One item can carry several responses: the series plus any occurrence the
+    // user answered individually. Each needs its own MeetingResponse command,
+    // and the changelog entry is only cleared once every one of them landed.
+    let allSent = true;
+    let lastStatus = null;
+
+    for (const response of inv.responses) {
+      let result = null;
+      try {
+        result = await sendMeetingResponse({
+          account: ctx.account,
+          asVersion: ctx.asVersion,
+          collectionId: ctx.collectionId,
+          serverID: inv.serverID,
+          userResponse: response.userResponseCode,
+          instanceId: response.instanceId,
+        });
+      } catch (err) {
+        ctx.provider.reportEventLog({
+          level: "warning",
+          accountId: ctx.accountId,
+          folderId: ctx.folderId,
+          message: `[${ctx.itemKind.changelogKind}-sync] MeetingResponse threw for itemId=${inv.entry.itemId}${response.instanceId ? ` instance=${response.instanceId}` : ""}: ${err?.message ?? String(err)}`,
+        });
+      }
+      if (!result || result.status !== STATUS_OK) {
+        allSent = false;
+        lastStatus = result?.status ?? "none";
+        continue;
+      }
+
+      // `existingItemId` means this came from the added_by_user duplicate
+      // path (matchInvitationResponse): `inv.item` is a stray duplicate
+      // Thunderbird's itip engine created, not the real synced item, so
+      // the response gets stamped onto the *existing* item instead. The
+      // duplicate is deliberately left alone rather than auto-deleted - a
+      // content-based match isn't a guaranteed-unique key, so this only
+      // clears its changelog entry (stopping the repeated push attempts)
+      // and leaves cleanup to the user, called out in the log below.
+      //
+      // Re-read the item for every response: stamping rewrites the blob, so a
+      // stale copy would clobber the previous stamp when one series carries
+      // more than one response.
+      const targetItemId = inv.existingItemId ?? inv.item.id;
+      const targetItem = await ctx.store.get(targetItemId);
+      if (targetItem?.blob) {
+        const stamped = ctx.itemKind.codec.stampInvitationResponse(
+          targetItem.blob,
+          response.newResponseType,
+          response.instanceId,
+        );
+        await ctx.store.update(targetItemId, stamped);
+      }
+      anySent = true;
     }
-    if (!result || result.status !== STATUS_OK) {
+
+    if (!allSent) {
       failedItems.add(inv.entry.itemId);
       ctx.provider.reportEventLog({
         level: "warning",
         accountId: ctx.accountId,
         folderId: ctx.folderId,
-        message: `[${ctx.itemKind.changelogKind}-sync] MeetingResponse failed for itemId=${inv.entry.itemId} (status=${result?.status ?? "none"})`,
+        message: `[${ctx.itemKind.changelogKind}-sync] MeetingResponse failed for itemId=${inv.entry.itemId} (status=${lastStatus}). Responses that did succeed are already stamped and will not be re-sent.`,
       });
       continue;
     }
-    // `existingItemId` means this came from the added_by_user duplicate
-    // path (matchInvitationResponse): `inv.item` is a stray duplicate
-    // Thunderbird's itip engine created, not the real synced item, so
-    // the response gets stamped onto the *existing* item instead. The
-    // duplicate is deliberately left alone rather than auto-deleted - a
-    // content-based match isn't a guaranteed-unique key, so this only
-    // clears its changelog entry (stopping the repeated push attempts)
-    // and leaves cleanup to the user, called out in the log below.
-    const targetItemId = inv.existingItemId ?? inv.item.id;
-    const targetItem = inv.existingItemId
-      ? await ctx.store.get(inv.existingItemId)
-      : inv.item;
-    if (targetItem?.blob) {
-      const stamped = ctx.itemKind.codec.stampInvitationResponse(
-        targetItem.blob,
-        inv.newResponseType,
-      );
-      await ctx.store.update(targetItemId, stamped);
-    }
+
     await ctx.provider.changelogRemove({
       accountId: ctx.accountId,
       folderId: ctx.folderId,
@@ -1094,7 +1132,6 @@ async function sendInvitationResponses(ctx, invitationResponses, failedItems) {
         message: `[${ctx.itemKind.changelogKind}-sync] itemId=${inv.entry.itemId} looked like a duplicate Thunderbird created while responding to an existing invite (itemId=${inv.existingItemId}); sent MeetingResponse using the existing item and dropped the duplicate's push. The duplicate local copy was left in place - delete it manually if it's still showing in your calendar.`,
       });
     }
-    anySent = true;
   }
   return anySent;
 }

--- a/src/modules/eas/sync-runner.mjs
+++ b/src/modules/eas/sync-runner.mjs
@@ -43,6 +43,7 @@ import { createWBXML } from "../wbxml.mjs";
 import { readPath, readPathFrom } from "./wbxml-helpers.mjs";
 import { runGetItemEstimate } from "./get-item-estimate.mjs";
 import { fetchServerItem } from "./item-operations.mjs";
+import { sendMeetingResponse } from "./meeting-response.mjs";
 import { easCommandLikelyAvailable } from "./allowed-commands.mjs";
 import {
   ok,
@@ -721,6 +722,16 @@ async function pushPhase(ctx, userEdits) {
     if (!slice.length) break;
 
     const built = await buildPushBatch(ctx, slice);
+
+    if (built.invitationResponses.length) {
+      const anySent = await sendInvitationResponses(
+        ctx,
+        built.invitationResponses,
+        failedItems,
+      );
+      if (anySent) changedAnything = true;
+    }
+
     if (!built.adds.length && !built.mods.length && !built.dels.length) {
       itemsDone += slice.length;
       reportProgress(ctx, itemsDone, itemsTotal);
@@ -876,10 +887,79 @@ async function buildPushBatch(ctx, slice) {
   const adds = [];
   const mods = [];
   const dels = [];
+  const invitationResponses = [];
+  // Lazily fetched, calendar-only: the folder's already-synced items, used
+  // to recognise an `added_by_user` entry that is actually Thunderbird's
+  // itip engine creating a duplicate of an existing received invite (see
+  // matchInvitationResponse's doc comment). Fetched at most once per
+  // batch, only if a Calendar entry needs it.
+  let syncedItemsForMatch = null;
+
   for (const entry of slice) {
     if (entry.status === "added_by_user") {
       const it = await ctx.store.get(entry.itemId);
       if (!it?.blob) continue;
+
+      // An item that already carries our own X-EAS-SERVERID is, by
+      // definition, already EAS-tracked - a genuinely new user-created
+      // item can never have one yet. An `added_by_user` entry for such
+      // an item can only be a stale changelog artifact (e.g. a race
+      // between applyAdd adopting a pre-existing Thunderbird-created
+      // item - see the UID-collision handling there - and the host's own
+      // calendar observer, which can still fire after that adopt writes
+      // to the item). Pushing it as a fresh Add would create a
+      // duplicate meeting server-side even though nothing is actually
+      // new; drop the stale entry instead. This check doesn't depend on
+      // timing at all, unlike trying to clear the changelog entry
+      // proactively during the pull.
+      const alreadyTrackedServerId =
+        ctx.itemKind.codec.readEasServerIdFromBlob(it.blob);
+      if (alreadyTrackedServerId) {
+        ctx.provider.reportEventLog({
+          level: "warning",
+          accountId: ctx.accountId,
+          folderId: ctx.folderId,
+          message: `[${ctx.itemKind.changelogKind}-sync] dropped stale added_by_user entry for itemId=${entry.itemId}: already EAS-tracked (serverID=${alreadyTrackedServerId})`,
+        });
+        await ctx.provider.changelogRemove({
+          accountId: ctx.accountId,
+          folderId: ctx.folderId,
+          parentId: entry.parentId,
+          itemId: entry.itemId,
+        });
+        continue;
+      }
+
+      const matcher = ctx.itemKind.codec.matchInvitationResponse;
+      if (matcher) {
+        if (syncedItemsForMatch === null) {
+          const all = await ctx.store.list();
+          syncedItemsForMatch = all.filter((si) => si.id !== entry.itemId);
+        }
+        const match = matcher({
+          candidateIcal: it.blob,
+          existingItems: syncedItemsForMatch,
+          userEmail: ctx.account?.custom?.user,
+        });
+        if (match && easCommandLikelyAvailable(ctx.account, "MeetingResponse")) {
+          const existingIt = await ctx.store.get(match.existingItemId);
+          const serverID = existingIt?.blob
+            ? ctx.itemKind.codec.readEasServerIdFromBlob(existingIt.blob)
+            : null;
+          if (serverID) {
+            invitationResponses.push({
+              entry,
+              serverID,
+              item: it,
+              userResponseCode: match.userResponseCode,
+              newResponseType: match.newResponseType,
+              existingItemId: match.existingItemId,
+            });
+            continue;
+          }
+        }
+      }
+
       const clientId = `c-${Date.now().toString(36)}-${adds.length}`;
       adds.push({ entry, clientId, item: it });
     } else if (entry.status === "modified_by_user") {
@@ -889,6 +969,23 @@ async function buildPushBatch(ctx, slice) {
         ctx.itemKind.codec.readEasServerIdFromBlob(it.blob) ??
         findServerIdByUid(ctx, entry.itemId);
       if (!serverID) continue;
+      // An itip Accept/Decline/Tentative just flips the self-attendee's
+      // PARTSTAT on an otherwise-unrelated received invite - that's not
+      // a generic edit, it's an RSVP, and must go out as a dedicated
+      // MeetingResponse (see calendar-codec.mjs's detectInvitationResponse
+      // doc comment for why this can be detected from data alone, no UI
+      // hook needed). Only reroute when the server actually advertises
+      // the command; otherwise fall through to the old generic-push
+      // behaviour rather than silently dropping the user's response.
+      const invitation =
+        ctx.itemKind.codec.detectInvitationResponse?.({
+          ical: it.blob,
+          userEmail: ctx.account?.custom?.user,
+        }) ?? null;
+      if (invitation && easCommandLikelyAvailable(ctx.account, "MeetingResponse")) {
+        invitationResponses.push({ entry, serverID, item: it, ...invitation });
+        continue;
+      }
       mods.push({ entry, serverID, item: it });
     } else if (entry.status === "deleted_by_user") {
       const serverID = findServerIdByUid(ctx, entry.itemId);
@@ -921,7 +1018,85 @@ async function buildPushBatch(ctx, slice) {
       dels.push({ entry, serverID });
     }
   }
-  return { adds, mods, dels };
+  return { adds, mods, dels, invitationResponses };
+}
+
+/* ── Invitation responses (MeetingResponse) ──────────────────────────
+ *
+ * Each entry is sent as its own MeetingResponse command - a different
+ * EAS command from Sync, so these go out ahead of (and separately
+ * from) the batch's `sendSync` call. Success clears the changelog entry
+ * and re-stamps X-EAS-RESPONSETYPE locally so the next sync pass doesn't
+ * re-detect the same already-sent response; failure adds the item to
+ * `failedItems`, reusing pushPhase's existing tail-restage retry path -
+ * no separate retry plumbing needed. */
+
+async function sendInvitationResponses(ctx, invitationResponses, failedItems) {
+  let anySent = false;
+  for (const inv of invitationResponses) {
+    let result = null;
+    try {
+      result = await sendMeetingResponse({
+        account: ctx.account,
+        asVersion: ctx.asVersion,
+        collectionId: ctx.collectionId,
+        serverID: inv.serverID,
+        userResponse: inv.userResponseCode,
+      });
+    } catch (err) {
+      ctx.provider.reportEventLog({
+        level: "warning",
+        accountId: ctx.accountId,
+        folderId: ctx.folderId,
+        message: `[${ctx.itemKind.changelogKind}-sync] MeetingResponse threw for itemId=${inv.entry.itemId}: ${err?.message ?? String(err)}`,
+      });
+    }
+    if (!result || result.status !== STATUS_OK) {
+      failedItems.add(inv.entry.itemId);
+      ctx.provider.reportEventLog({
+        level: "warning",
+        accountId: ctx.accountId,
+        folderId: ctx.folderId,
+        message: `[${ctx.itemKind.changelogKind}-sync] MeetingResponse failed for itemId=${inv.entry.itemId} (status=${result?.status ?? "none"})`,
+      });
+      continue;
+    }
+    // `existingItemId` means this came from the added_by_user duplicate
+    // path (matchInvitationResponse): `inv.item` is a stray duplicate
+    // Thunderbird's itip engine created, not the real synced item, so
+    // the response gets stamped onto the *existing* item instead. The
+    // duplicate is deliberately left alone rather than auto-deleted - a
+    // content-based match isn't a guaranteed-unique key, so this only
+    // clears its changelog entry (stopping the repeated push attempts)
+    // and leaves cleanup to the user, called out in the log below.
+    const targetItemId = inv.existingItemId ?? inv.item.id;
+    const targetItem = inv.existingItemId
+      ? await ctx.store.get(inv.existingItemId)
+      : inv.item;
+    if (targetItem?.blob) {
+      const stamped = ctx.itemKind.codec.stampInvitationResponse(
+        targetItem.blob,
+        inv.newResponseType,
+      );
+      await ctx.store.update(targetItemId, stamped);
+    }
+    await ctx.provider.changelogRemove({
+      accountId: ctx.accountId,
+      folderId: ctx.folderId,
+      parentId: inv.entry.parentId,
+      itemId: inv.entry.itemId,
+    });
+    if (inv.existingItemId) {
+      ctx.provider.reportEventLog({
+        level: "warning",
+        accountId: ctx.accountId,
+        folderId: ctx.folderId,
+        message: `[${ctx.itemKind.changelogKind}-sync] itemId=${inv.entry.itemId} looked like a duplicate Thunderbird created while responding to an existing invite (itemId=${inv.existingItemId}); sent MeetingResponse using the existing item and dropped the duplicate's push. The duplicate local copy was left in place - delete it manually if it's still showing in your calendar.`,
+      });
+    }
+    anySent = true;
+  }
+  return anySent;
 }
 
 /* ── Apply responses to our push ──────────────────────────────────── */
@@ -1084,7 +1259,18 @@ async function applyAdd(ctx, addNode) {
   const existing = await findExistingByServerId(ctx, serverID);
   if (existing) return applyChangeFromAd(ctx, ad, existing);
 
-  const newId = crypto.randomUUID();
+  // Prefer the server's real UID (present on ≤14.x Add responses - see
+  // calendar-codec.mjs's applicationDataToIcal comment on Organizer/UID
+  // for the matching 16.1 caveat) as the local item's id/UID instead of
+  // a random one. Thunderbird's own itip engine matches invitation
+  // responses to an existing calendar item by UID across ALL calendars
+  // - if our stored copy carries the same UID the server/organizer used,
+  // Accepting an already-synced invite lands as a modifyItem TbSync can
+  // see and reroute (detectInvitationResponse), instead of a same-titled
+  // duplicate `addItem` TbSync can't tell apart from a real new meeting.
+  // Falls back to a random id when the AD has no UID (16.1, or Tasks -
+  // which have no UID field at all) - unchanged from prior behaviour.
+  const newId = readPathFrom(ad, ["UID"]) || crypto.randomUUID();
   const blob = await ctx.itemKind.codec.applicationDataToBlob({
     adNode: ad,
     serverID,
@@ -1105,6 +1291,100 @@ async function applyAdd(ctx, addNode) {
     status: "added_by_server",
     kind: ctx.itemKind.changelogKind,
   });
+
+  // Using the server's real UID above means a local item under that
+  // exact id can already exist here - Thunderbird's own itip engine may
+  // have created it (e.g. Accept clicked on an emailed invite before
+  // this pull ran; the mirror-image race is handled on the push side by
+  // matchInvitationResponse in buildPushBatch). Adopt it in place rather
+  // than risk a second `create` with a colliding id, which the native
+  // calendar may reject outright or clobber unpredictably. Trade-off:
+  // this overwrites whatever PARTSTAT the user already set via itip
+  // locally back to the server's (not-yet-updated) state - re-accepting
+  // after this sync will correctly route through MeetingResponse since
+  // the item is now EAS-tracked.
+  const preExisting = await ctx.store.get(newId);
+  if (preExisting) {
+    const userEmail = ctx.account?.custom?.user;
+    // Carry over any PARTSTAT the user already set via itip before this
+    // pull ran (e.g. clicked Accept on the emailed invite), so adopting
+    // the item doesn't silently revert it to NEEDS-ACTION.
+    const preservedBlob = ctx.itemKind.codec.preserveSelfPartstat
+      ? ctx.itemKind.codec.preserveSelfPartstat({
+          builtIcal: blob,
+          priorIcal: preExisting.blob,
+          userEmail,
+        })
+      : blob;
+    await ctx.store.update(newId, preservedBlob);
+    await verifyRoundTrip(ctx, newId, preservedBlob, "update");
+    upsertIndexMap(ctx, newId, serverID);
+    // The pre-existing item predates any EAS tracking, so it was almost
+    // certainly sitting in the changelog as its own `added_by_user` (or
+    // `modified_by_user`) entry from whatever local write created/touched
+    // it (e.g. the itip Accept itself). That entry now refers to stale
+    // pre-adoption content we just overwrote with the server's data - if
+    // left in place, the next push phase would send it out as a generic
+    // Add/Change (a self-match `matchInvitationResponse` can't catch,
+    // since this item is now the only copy, not a duplicate of another
+    // one). Clear it explicitly rather than let a "changelogMarkServerWrite
+    // + store.update" for a *different* itemId leave this one stale.
+    await ctx.provider.changelogRemove({
+      accountId: ctx.accountId,
+      folderId: ctx.folderId,
+      parentId: ctx.targetID,
+      itemId: newId,
+    });
+    // Since the stale changelog entry above is dropped rather than
+    // pushed, a PARTSTAT the user already set (just preserved onto
+    // preservedBlob) would otherwise never reach the server at all -
+    // send the MeetingResponse right here instead of waiting for a
+    // second Accept click to produce a fresh modified_by_user entry.
+    const invitation = ctx.itemKind.codec.detectInvitationResponse?.({
+      ical: preservedBlob,
+      userEmail,
+    });
+    if (invitation) {
+      const result = await sendMeetingResponse({
+        account: ctx.account,
+        asVersion: ctx.asVersion,
+        collectionId: ctx.collectionId,
+        serverID,
+        userResponse: invitation.userResponseCode,
+      }).catch((err) => {
+        ctx.provider.reportEventLog({
+          level: "warning",
+          accountId: ctx.accountId,
+          folderId: ctx.folderId,
+          message: `[${ctx.itemKind.changelogKind}-sync] MeetingResponse threw while adopting itemId=${newId}: ${err?.message ?? String(err)}`,
+        });
+        return null;
+      });
+      if (result?.status === STATUS_OK) {
+        const stamped = ctx.itemKind.codec.stampInvitationResponse(
+          preservedBlob,
+          invitation.newResponseType,
+        );
+        await ctx.store.update(newId, stamped);
+      } else {
+        ctx.provider.reportEventLog({
+          level: "warning",
+          accountId: ctx.accountId,
+          folderId: ctx.folderId,
+          message: `[${ctx.itemKind.changelogKind}-sync] MeetingResponse failed while adopting itemId=${newId} (status=${result?.status ?? "none"})`,
+        });
+      }
+    }
+    if (blobHasRecurrence(preservedBlob)) {
+      logRecurrence(
+        ctx,
+        `pull add (adopted pre-existing item): itemId=${newId}, serverID=${serverID}`,
+        { ical: preservedBlob },
+      );
+    }
+    return;
+  }
+
   const createdId = await ctx.store.create(newId, blob);
   if (createdId !== newId) {
     throw new Error(


### PR DESCRIPTION
> **Ported from the v4 implementation ([NielBuys/EAS-4-TbSync#13](https://github.com/NielBuys/EAS-4-TbSync/pull/13)) and NOT yet tested on v5.**
> The v4 original was verified end-to-end against Exchange Online (16.1); this port has only been read, syntax-checked and built. Please treat it as a starting point to test, not as ready to merge.

Supersedes / includes **#329** by @tomaskovacik — his commit is carried here unchanged, with authorship intact, rebased onto current `master` (it was 14 commits behind, so a PR from that branch would have reverted v5.0.12 along with the resync-duplication, token-rotation and reauth fixes). This PR adds one commit on top: per-occurrence responses, which #329 listed as out of scope.

A test build is attached below.

## Commit 1 — MeetingResponse (@tomaskovacik, #329)

Unchanged from #329. Accepting or declining a meeting invitation never told Exchange anything through the protocol-correct channel; the itip-driven PARTSTAT edit got pushed back as a plain `Sync <Add>`/`<Change>`, which Exchange reads as the user creating a new self-organized meeting — duplicating the event and re-inviting every attendee.

## Commit 2 — answer a single occurrence (`InstanceId`)

`detectInvitationResponse` only inspects the master VEVENT. But a whole recurring series is a single EAS item, and Thunderbird records an Accept clicked on one occurrence by creating an **exception** for it — which is what answering a recurring invitation from the calendar view *always* does. So per-occurrence responses were never detected: the RSVP was silently lost and the change fell through to a generic push that tells the server nothing.

We hit this as the *normal* path, not an edge case, while implementing the same feature for v4 — for recurring meetings, responding from the calendar view never worked at all.

- **`calendar-codec.mjs`** — `detectInvitationResponses()` walks the master and every VEVENT carrying a `RECURRENCE-ID`, returning one response per pending answer. The marker comparison moves into `compareSelfPartstat()` so both share it; `detectInvitationResponse()` remains as the master-only wrapper the `applyAdd` adopt path uses. `stampInvitationResponse()` takes an optional `instanceId` and stamps that override rather than the series.
- **`meeting-response.mjs`** — optional `instanceId`, emitted after `RequestId`.
- **`sync-runner.mjs`** — one `MeetingResponse` per detected response; the changelog entry is cleared only once all of them landed, and each stamp re-reads the item so several responses on one series cannot clobber each other.

### The trap worth knowing about

**There are two different `InstanceId` elements and they take different formats.**

| element | required length | form |
|---|---|---|
| `ProposedStartTime` / `ProposedEndTime` (same schema) | 16 | `20260810T074500Z` |
| AirSyncBase `InstanceId` (16.1 exception edits) | 16 | `20260810T074500Z` |
| **MeetingResponse `InstanceId`** | **24** | **`2026-08-10T07:45:00.000Z`** |

`MeetingResponseRequest.xsd` restricts it to exactly 24 characters. Sending the 16-character basic form is answered with `Status 2` ("invalid meeting request"), which is indistinguishable from a genuinely stale or deleted meeting — the response gives no hint that the format is the problem. This cost a full debug cycle on the v4 side. Both the codec helper and `sendMeetingResponse` guard on the length so a malformed value is never sent, and the comments say why.

## Testing

**Untested on v5.** No Exchange account available here to exercise it against.

What *is* verified is the equivalent v4 implementation, against Exchange Online on 16.1, with the local calendar store inspected directly rather than trusting the UI:

- per-occurrence Accept → `MeetingResponse` with `InstanceId`, `Status=1`, accepted in Outlook Web, stamped on that occurrence only, series and other occurrences untouched
- series-level Decline, from both `NEEDS-ACTION` and `ACCEPTED`
- accepting from the invitation e-mail (the duplicate path), matched exactly on the invitation UID
- no repeat send on subsequent syncs; a failed response retried rather than lost — confirmed precisely by the `Status 2` failure above, which succeeded once the format was fixed

Worth a review pass on whether `meetingStatusFor()`'s fallback to the master's `X-EAS-MEETINGSTATUS` for overrides matches what your server actually sends — that one is inference from the v4 data, not something confirmable here.

## Separate issue, flagged rather than bundled

Once `ATTENDEESTATUS_TO_PARTSTAT[5]` changes from `ACCEPTED` to `NEEDS-ACTION` (commit 1), items written by an *earlier* build still carry a `PARTSTAT` produced by the old mapping. `detectInvitationResponse` then compares a live `ACCEPTED` against a stamped `X-EAS-RESPONSETYPE=5` that now reads as `NEEDS-ACTION`, sees a transition, and fires a `MeetingResponse` for an invitation the user never answered — on *any* local write to the item, including Thunderbird acknowledging a reminder.

This bit us for real on v4. The fix there was to write the marker as the PARTSTAT last taken from server data, under a **new** property name, so its absence means "server-side status unknown" and detection backs off entirely until the item has been re-read. Some equivalent guard is probably wanted here before this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
