### PR TITLE
Add an automated test harness (vitest) for the codec/wbxml/sync-runner core

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ["20.x", "22.x"]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - run: npm ci
+      - run: npm test

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,10 @@
+# Reproducible local test run, matching what CI does.
+#
+# Build:  docker build -f Dockerfile.test -t eas-4-tbsync-tests .
+# Run:    docker run --rm eas-4-tbsync-tests
+FROM node:20-slim
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+CMD ["npm", "test"]

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,81 @@
+# Automated tests
+
+An automated test harness for the pure-logic parts of this add-on: EAS
+WBXML `<ApplicationData>` ↔ iCal/vCard conversion, the WBXML request/
+response helpers, and the push/pull orchestration in `sync-runner.mjs`.
+It does not (and cannot, from Node) drive Thunderbird itself - see
+"Known gap" below.
+
+## How to run
+
+```
+npm ci
+npm test
+```
+
+`vitest run`, zero config beyond `package.json`'s `test` script. CI runs
+it on a Node 20.x/22.x matrix via `.github/workflows/test.yml`.
+`Dockerfile.test` reproduces the same run locally:
+
+```
+docker build -f Dockerfile.test -t eas-4-tbsync-tests .
+docker run --rm eas-4-tbsync-tests
+```
+
+## What's covered
+
+- `calendar-codec.mjs`: inbound `<ApplicationData>` → iCal (single event,
+  whole-series RRULE, 16.1 per-occurrence `InstanceId` edits/deletes,
+  14.x embedded `<Exceptions>`) and the outbound reverse, round-tripped
+  through the real WBXML encoder/decoder (`wbxml.mjs`), not a stub.
+- `task-codec.mjs` / `contact-codec.mjs`: field mapping and the
+  merge-aware "a delta without this tag leaves the existing value
+  untouched" behavior each codec relies on.
+- `wbxml-helpers.mjs` / `timezone-blob.mjs`: the small parsing utilities
+  everything else depends on.
+- `sync-runner.mjs`'s push orchestration: `appendCommands` and
+  `applyResponses` are exported test-only (every production caller still
+  reaches them through the normal `pushPhase`/`runOneSync` flow) so two
+  request/response shapes can be driven directly without mocking the
+  network.
+
+Two of those double as regression evidence for filed issues:
+
+- `sync-runner.bundled-instance-change.test.mjs` demonstrates that a
+  modified recurring item's master `<Change>` and its per-occurrence
+  `InstanceId` `<Change>` get sent under the same `ServerId` in one
+  `<Sync>` request, and documents today's retry/changelog behavior when
+  a server rejects both (see #334).
+- `calendar-codec.inbound-exceptions.test.mjs` documents that a second,
+  status-only touch of an already-synced recurrence exception drops its
+  Subject/Start/End locally, because the exception is rebuilt from an
+  empty component on every update with no inheritance from the prior
+  state (see #342).
+
+Both are written as characterization tests - they assert today's actual
+behavior on purpose, so a fix has to touch the test file rather than
+land unverified.
+
+## Tooling choices
+
+Real WBXML round-trips and real captured wire fixtures wherever
+practical, instead of hand-written XML approximations - `createWBXML`/
+`decodeWBXML` are exercised directly. [vitest](https://vitest.dev) is
+the only dependency this adds; `vi.mock`/`vi.hoisted` cover the one seam
+that needs mocking (the network call in the `sync-runner` push test).
+
+## Known gap: the WebExtension host boundary
+
+`timezone-mapping.mjs`'s `ensureLoaded()` needs
+`messenger.calendar.timezones.*` (Thunderbird's own calendar backend),
+unavailable outside Thunderbird. `tests/support/webext-shim.mjs` shims
+just enough for the common UTC-only path - `"UTC"` short-circuits before
+ever needing real per-zone data. Tests requiring a specific non-UTC IANA
+zone resolution are out of scope here and stay manual-test territory.
+
+## Scope of this branch
+
+This covers only code paths that exist on `master` as of this branch.
+MeetingResponse (Accept/Decline/Tentative, #339) isn't merged yet, so
+tests for it aren't part of this PR; they'll follow as a separate PR
+once #339 lands.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,750 @@
+{
+  "name": "eas-4-tbsync",
+  "version": "5.0.13",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "eas-4-tbsync",
+      "version": "5.0.13",
+      "devDependencies": {
+        "vitest": "^4.1.10"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "2.0.0-alpha.3",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "2.0.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "2.0.0-alpha.3",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.2",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.142.0",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.1",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.1",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "2.0.0-alpha.3",
+        "@emnapi/runtime": "2.0.0-alpha.3",
+        "@napi-rs/wasm-runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.25",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.142.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.1",
+        "@rolldown/binding-darwin-arm64": "1.2.1",
+        "@rolldown/binding-darwin-x64": "1.2.1",
+        "@rolldown/binding-freebsd-x64": "1.2.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.1",
+        "@rolldown/binding-linux-arm64-musl": "1.2.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.1",
+        "@rolldown/binding-linux-x64-gnu": "1.2.1",
+        "@rolldown/binding-linux-x64-musl": "1.2.1",
+        "@rolldown/binding-openharmony-arm64": "1.2.1",
+        "@rolldown/binding-wasm32-wasi": "1.2.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.1",
+        "@rolldown/binding-win32-x64-msvc": "1.2.1"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/vite": {
+      "version": "8.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.23",
+        "rolldown": "~1.2.0",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "scripts": {
     "build": "node build.js",
     "dev": "node build.js --dev",
-    "version": "node build.js && git add src"
+    "version": "node build.js && git add src",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.10"
   }
 }

--- a/src/modules/eas/sync-runner.mjs
+++ b/src/modules/eas/sync-runner.mjs
@@ -953,7 +953,9 @@ async function buildPushBatch(ctx, slice) {
 
 /* ── Apply responses to our push ──────────────────────────────────── */
 
-async function applyResponses(ctx, responses, sent, failedItems, opts = {}) {
+// Exported for tests only - every production caller still reaches this
+// through the pushPhase loop inside runOneSync.
+export async function applyResponses(ctx, responses, sent, failedItems, opts = {}) {
   const { hadResponsesElement = true } = opts;
   if (!hadResponsesElement) {
     const sentCount = sent.adds.length + sent.mods.length + sent.dels.length;
@@ -1360,7 +1362,9 @@ function buildSyncBody({
   return w.getBytes();
 }
 
-function appendCommands(
+// Exported for tests only - every production caller still reaches this
+// through buildSyncBody inside pushPhase.
+export function appendCommands(
   w,
   {
     adds,

--- a/tests/integration/sync-runner.bundled-instance-change.test.mjs
+++ b/tests/integration/sync-runner.bundled-instance-change.test.mjs
@@ -1,0 +1,149 @@
+// jobisoft#334's root cause, at the orchestration level: appendCommands
+// (sync-runner.mjs) writes the master's own <Change> for a modified item,
+// then - still inside the same <Commands> block, i.e. the same <Sync>
+// request - calls codec.appendInstanceChanges to append one more <Change>
+// per edited/deleted occurrence, addressed by the SAME ServerId as the
+// master (16.1's InstanceId shape). calendar-codec.outbound-edits.test.mjs
+// already proves appendInstanceChanges' own output is correct in
+// isolation; what's untested until now is that sync-runner.mjs actually
+// bundles it alongside the master Change rather than sending it
+// separately - which is exactly the shape Exchange rejects live (both
+// commands come back Status 6, "invalid item").
+//
+// This is a characterization test: it asserts today's actual behavior
+// (the bundling happens, and a same-ServerId double-rejection leaves the
+// item queued for retry rather than silently dropped or falsely cleared)
+// so a future fix - splitting the occurrence Change into its own <Sync>
+// request - is forced to touch this file rather than land unverified.
+
+import { test, beforeAll } from "vitest";
+import assert from "node:assert/strict";
+import "../support/webext-shim.mjs";
+import { ensureLoaded } from "../../src/modules/eas/timezone-mapping.mjs";
+import { createWBXML, decodeWBXML } from "../../src/modules/wbxml.mjs";
+import { parseAdNode } from "../support/xml-node.mjs";
+import { readPathFrom } from "../../src/modules/eas/wbxml-helpers.mjs";
+import { realCalendarCodec } from "../support/real-calendar-codec.mjs";
+import {
+  appendCommands,
+  applyResponses,
+} from "../../src/modules/eas/sync-runner.mjs";
+
+beforeAll(() => ensureLoaded());
+
+// Master series plus one edited (not deleted) occurrence - the same
+// fixture shape as calendar-codec.outbound-edits.test.mjs's
+// appendInstanceChanges "overrides" test, so this test is provably
+// exercising the same live-rejected wire shape, just one layer up.
+const SERIES_WITH_OVERRIDE = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:0400-bundled-series-uid
+DTSTAMP:20260801T090000Z
+DTSTART:20260801T100000Z
+DTEND:20260801T103000Z
+SUMMARY:test-bundled-series
+RRULE:FREQ=WEEKLY;INTERVAL=1;UNTIL=20260901T100000Z;BYDAY=SA
+END:VEVENT
+BEGIN:VEVENT
+UID:0400-bundled-series-uid
+RECURRENCE-ID:20260808T100000Z
+DTSTAMP:20260801T090000Z
+DTSTART:20260808T140000Z
+DTEND:20260808T143000Z
+SUMMARY:test-bundled-series (one occurrence moved)
+END:VEVENT
+END:VCALENDAR
+`;
+
+test("appendCommands bundles the master Change and the occurrence's InstanceId Change under one ServerId in a single Commands block (the shape Exchange rejects)", () => {
+  const mod = {
+    entry: { itemId: "item-1", parentId: "calendar1" },
+    serverID: "server-id-bundled",
+    item: { id: "item-1", blob: SERIES_WITH_OVERRIDE },
+  };
+
+  const w = createWBXML("AirSync");
+  appendCommands(w, {
+    adds: [],
+    mods: [mod],
+    dels: [],
+    separator: ",",
+    asVersion: "16.1",
+    codec: realCalendarCodec(),
+    defaultTimezone: "UTC",
+    syncRecurrence: true,
+    userEmail: "kovacik@dgtfactory.com",
+    fallbackOrganizerName: undefined,
+    eventLog: () => {},
+  });
+
+  const commandsNode = parseAdNode(decodeWBXML(w.getBytes()));
+  const changeNodes = commandsNode.children.filter(
+    (c) => c.tagName === "Change",
+  );
+
+  // Both the master's own edit and the occurrence's InstanceId edit went
+  // out as <Change> commands sharing the master's ServerId, in the same
+  // request - the actual bundling jobisoft#334 is about.
+  assert.equal(changeNodes.length, 2);
+  assert.equal(readPathFrom(changeNodes[0], ["ServerId"]), "server-id-bundled");
+  assert.equal(readPathFrom(changeNodes[1], ["ServerId"]), "server-id-bundled");
+  const masterAd = changeNodes[0].children.find(
+    (c) => c.tagName === "ApplicationData",
+  );
+  assert.equal(readPathFrom(masterAd, ["InstanceId"]), null);
+  const occurrenceAd = changeNodes[1].children.find(
+    (c) => c.tagName === "ApplicationData",
+  );
+  assert.equal(
+    readPathFrom(occurrenceAd, ["InstanceId"]),
+    "20260808T100000Z",
+  );
+});
+
+test("applyResponses: when both bundled Changes come back Status 6 (live Exchange rejection), the item is queued for retry, not silently cleared", async () => {
+  const changelogRemoveCalls = [];
+  const provider = {
+    changelogRemove: async (args) => changelogRemoveCalls.push(args),
+    reportEventLog: () => {},
+  };
+  const ctx = { accountId: "acc1", folderId: "folder1", provider };
+
+  const mod = {
+    entry: { itemId: "item-1", parentId: "calendar1" },
+    serverID: "server-id-bundled",
+    item: { id: "item-1", blob: SERIES_WITH_OVERRIDE },
+  };
+  const sent = { adds: [], mods: [mod], dels: [] };
+
+  // The server rejects each of the two bundled Change commands with its
+  // own Status 6 response node, both stamped with the shared ServerId -
+  // exactly what was captured live during the jobisoft#334 investigation.
+  const responses = {
+    adds: [],
+    changes: [
+      parseAdNode(
+        `<Change><ServerId>server-id-bundled</ServerId><Status>6</Status></Change>`,
+      ),
+      parseAdNode(
+        `<Change><ServerId>server-id-bundled</ServerId><Status>6</Status></Change>`,
+      ),
+    ],
+    deletes: [],
+  };
+
+  const failedItems = new Set();
+  await applyResponses(ctx, responses, sent, failedItems, {
+    hadResponsesElement: true,
+  });
+
+  // pushPhase's tail re-stage relies on this: the item is retried next
+  // sync rather than dropped.
+  assert.ok(failedItems.has("item-1"));
+  // The changelog entry must NOT be cleared on a real failure - clearing
+  // it here would silently drop the user's edit (both the reschedule and
+  // the moved occurrence) with no further retry, which is worse than the
+  // live symptom (a stuck retry loop) this bundling bug actually causes.
+  assert.equal(changelogRemoveCalls.length, 0);
+});

--- a/tests/integration/sync-runner.no-responses-fallback.test.mjs
+++ b/tests/integration/sync-runner.no-responses-fallback.test.mjs
@@ -1,0 +1,102 @@
+// MS-ASCMD allows a Sync push reply to come back Status 1 at the
+// collection level with no per-command <Responses> element at all - a
+// terser "everything you sent was accepted" reply some servers send
+// instead of ACKing each command individually. sendSync/parseSyncResponse
+// turns that into `responses: null`; pushPhase then falls back to
+// `{ adds: [], changes: [], deletes: [] }` and tells applyResponses via
+// `hadResponsesElement: false`.
+//
+// This is the exact mechanism behind a delete that looked successful
+// live when it wasn't (see TEST-PLAN.md / project memory): with no
+// per-command Responses to match against, applyResponses' fallback loops
+// treat every sent mod and delete as an implicit success (no ack found ==
+// no ack needed), clearing their changelog entries unconditionally. Sent
+// *adds* are the odd one out: an Add can only be resolved by reading back
+// the ServerId the server assigned it, and with no <Responses> element
+// there's no ServerId anywhere - so adds are silently left pending
+// instead, unlike mods/dels.
+//
+// A characterization test: this documents today's actual (asymmetric,
+// optimistic-for-mods/dels) behavior so a future change to it is
+// deliberate, not accidental.
+
+import { test } from "vitest";
+import assert from "node:assert/strict";
+import { applyResponses } from "../../src/modules/eas/sync-runner.mjs";
+
+test("applyResponses with no <Responses> element: mods and deletes are treated as silently successful, adds are left pending", async () => {
+  const changelogRemoveCalls = [];
+  const eventLogs = [];
+  const provider = {
+    changelogRemove: async (args) => changelogRemoveCalls.push(args),
+    reportEventLog: (args) => eventLogs.push(args),
+  };
+  const indexMap = [
+    { uid: "del-item", serverId: "server-id-del" },
+    { uid: "mod-item", serverId: "server-id-mod" },
+  ];
+  const ctx = { accountId: "acc1", folderId: "folder1", provider, indexMap };
+
+  const sent = {
+    adds: [
+      {
+        entry: { itemId: "add-item", parentId: "calendar1" },
+        clientId: "c-1",
+        item: { id: "add-item", blob: "BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n" },
+      },
+    ],
+    mods: [
+      {
+        entry: { itemId: "mod-item", parentId: "calendar1" },
+        serverID: "server-id-mod",
+        item: { id: "mod-item", blob: "BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n" },
+      },
+    ],
+    dels: [
+      {
+        entry: { itemId: "del-item", parentId: "calendar1" },
+        serverID: "server-id-del",
+      },
+    ],
+  };
+
+  const failedItems = new Set();
+  await applyResponses(
+    ctx,
+    { adds: [], changes: [], deletes: [] },
+    sent,
+    failedItems,
+    { hadResponsesElement: false },
+  );
+
+  // The mod and the delete both get their changelog entries cleared with
+  // no server confirmation at all - the false-positive-success fallback.
+  assert.deepEqual(
+    changelogRemoveCalls.map((c) => c.itemId).sort(),
+    ["del-item", "mod-item"],
+  );
+  // The delete's indexMap entry is removed right along with it.
+  assert.equal(
+    indexMap.find((e) => e.uid === "del-item"),
+    undefined,
+  );
+
+  // The add is NOT resolved - no ServerId to stamp it with, so it's left
+  // as-is (still pending in the changelog, unstamped) rather than guessed
+  // at. It will be re-sent as an Add again on the next push.
+  assert.equal(
+    changelogRemoveCalls.some((c) => c.itemId === "add-item"),
+    false,
+  );
+
+  // Nothing was marked failed either - the fallback path has no notion
+  // of per-item failure when there's nothing to compare against.
+  assert.equal(failedItems.size, 0);
+
+  // The debug log documenting the fallback fired, counting all 3 sent
+  // items (1 add + 1 mod + 1 del) even though only 2 were actually
+  // resolved.
+  assert.equal(eventLogs.length, 1);
+  assert.equal(eventLogs[0].level, "debug");
+  assert.match(eventLogs[0].message, /no <Responses>.*clearing 3 sent items/);
+});

--- a/tests/support/mock-doc.mjs
+++ b/tests/support/mock-doc.mjs
@@ -1,0 +1,21 @@
+/**
+ * Wraps a node built by `parseAdNode` (or any `{tagName, textContent,
+ * children}` tree) into the shape `network.mjs`'s real decoded `doc`
+ * has: a `documentElement` plus a `getElementsByTagName` that does a
+ * recursive descendant search. Used to build canned `easRequest`
+ * responses for integration tests that mock the network seam.
+ */
+export function toMockDoc(rootNode) {
+  return {
+    documentElement: rootNode,
+    getElementsByTagName(tag) {
+      const out = [];
+      (function walk(node) {
+        if (!node) return;
+        if (node.tagName === tag) out.push(node);
+        for (const c of node.children ?? []) walk(c);
+      })(rootNode);
+      return out;
+    },
+  };
+}

--- a/tests/support/real-calendar-codec.mjs
+++ b/tests/support/real-calendar-codec.mjs
@@ -1,0 +1,49 @@
+/**
+ * The same `itemKind.codec` adapter shape `calendar-sync.mjs`'s (private,
+ * unexported) `makeCodec()` builds around `calendar-codec.mjs` - kept
+ * here so integration tests can drive `sync-runner.mjs` against the
+ * real codec logic instead of a stub, without duplicating production's
+ * wiring by hand in every test file.
+ */
+import * as modCodec from "../../src/modules/eas/calendar-codec.mjs";
+
+export function realCalendarCodec() {
+  return {
+    applicationDataToBlob({
+      adNode,
+      existingBlob,
+      serverID,
+      asVersion,
+      defaultTimezone,
+      syncRecurrence,
+      msTodoCompat,
+      uid,
+      userEmail,
+      eventLog,
+    }) {
+      return modCodec.applicationDataToIcal({
+        adNode,
+        existingIcal: existingBlob,
+        serverID,
+        asVersion,
+        defaultTimezone,
+        syncRecurrence,
+        msTodoCompat,
+        uid,
+        userEmail,
+        eventLog,
+      });
+    },
+    appendApplicationDataFromBlob(args) {
+      return modCodec.appendApplicationDataFromIcal({
+        ...args,
+        ical: args.blob,
+      });
+    },
+    readEasServerIdFromBlob: modCodec.readEasServerIdFromIcal,
+    stampEasServerId: modCodec.stampEasServerId,
+    applyInstanceChange: modCodec.applyInstanceChange,
+    applyInstanceDelete: modCodec.applyInstanceDelete,
+    appendInstanceChanges: modCodec.appendInstanceChanges,
+  };
+}

--- a/tests/support/webext-shim.mjs
+++ b/tests/support/webext-shim.mjs
@@ -1,0 +1,73 @@
+/**
+ * Minimal stand-in for the `browser`/`messenger` WebExtension globals,
+ * just enough for `timezone-mapping.mjs`'s `ensureLoaded()` to complete
+ * outside Thunderbird.
+ *
+ * `ensureLoaded()` needs two real files (WindowsTimezone.csv/Aliases.csv,
+ * read via `browser.runtime.getURL` + `fetch`, both fully vendored in
+ * this repo so no faking there) and a Thunderbird-calendar-provided list
+ * of known IANA zones with full VTIMEZONE definitions
+ * (`messenger.calendar.timezones.*`), which we do NOT have outside a
+ * running Thunderbird. We don't fake that data - we just don't offer any:
+ * `timezoneIds: []` and `currentZone: "UTC"`. Per timezone-mapping.mjs's
+ * own `loadTzInfo`, "UTC" (and "floating") short-circuit before ever
+ * calling `getDefinition`, and UTC is unconditionally pinned into the
+ * resolver's tables regardless of what `timezoneIds` contains - so this
+ * is enough for `ensureLoaded()` to succeed and for every test that only
+ * needs UTC-resolution (the common case: EAS 16.1 sends UTC times with
+ * no per-event TimeZone blob at all).
+ *
+ * Tests that need a *specific* non-UTC IANA zone resolved are out of
+ * scope for this shim - see TEST-PLAN.md's "known gaps" section.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const SRC_ROOT = fileURLToPath(new URL("../../src/", import.meta.url));
+
+globalThis.messenger = {
+  calendar: {
+    timezones: {
+      currentZone: "UTC",
+      timezoneIds: [],
+      async getDefinition() {
+        return null;
+      },
+    },
+  },
+  // contact-codec.mjs's readEmails() calls this to pull a bare address
+  // out of a "Display Name <addr@example.com>" mailbox string. Real
+  // Thunderbird's parser handles far more (quoted names, multiple
+  // addresses, malformed input); this is only enough for the plain
+  // "name <addr>" / bare-address fixtures the contact-codec tests use.
+  messengerUtilities: {
+    async parseMailboxString(raw) {
+      const m = /<([^>]+)>/.exec(raw);
+      return [{ email: m ? m[1] : raw }];
+    },
+  },
+};
+
+globalThis.browser = {
+  runtime: {
+    getURL(relativePath) {
+      return `webext-fixture:${relativePath}`;
+    },
+  },
+};
+
+const realFetch = globalThis.fetch?.bind(globalThis);
+
+globalThis.fetch = async (url) => {
+  const s = String(url);
+  if (s.startsWith("webext-fixture:")) {
+    const relativePath = s.slice("webext-fixture:".length);
+    const text = readFileSync(SRC_ROOT + relativePath, "utf8");
+    return { text: async () => text };
+  }
+  if (!realFetch) {
+    throw new Error(`webext-shim: no real fetch available for ${s}`);
+  }
+  return realFetch(url);
+};

--- a/tests/support/xml-node.mjs
+++ b/tests/support/xml-node.mjs
@@ -1,0 +1,71 @@
+/**
+ * Minimal recursive-descent parser turning a captured EAS wire XML
+ * snippet - pasted verbatim from the TbSync debug log, e.g. a single
+ * `<ApplicationData>...</ApplicationData>` or `<Exception>...</Exception>`
+ * element - into the lightweight `{tagName, textContent, children}` node
+ * shape that `wbxml-helpers.mjs`'s `childByTag`/`readPathFrom`/
+ * `readChildTexts` consume.
+ *
+ * This is deliberately NOT a general XML parser: no entities, no CDATA,
+ * no comments, attribute values are skipped rather than parsed (the
+ * codec never reads them - EAS carries everything as element text,
+ * percent-encoded the same way `decodeText` in wbxml-helpers.mjs
+ * expects). That narrow scope is what makes it safe to hand-roll instead
+ * of pulling in a real XML/DOM dependency: it only has to match what the
+ * real WBXML decoder already hands the codec, and real captured payloads
+ * are exactly what we test against, so any mismatch shows up immediately
+ * as a failing fixture rather than a silent divergence.
+ */
+
+export function parseAdNode(xml) {
+  const src = xml.replace(/^\s*<\?xml[^?]*\?>\s*/i, "").trim();
+  let i = 0;
+
+  function skipWs() {
+    while (i < src.length && /\s/.test(src[i])) i++;
+  }
+
+  function readTagName() {
+    const start = i;
+    while (i < src.length && !/[\s/>]/.test(src[i])) i++;
+    const raw = src.slice(start, i);
+    const colon = raw.lastIndexOf(":");
+    return colon === -1 ? raw : raw.slice(colon + 1);
+  }
+
+  function parseElement() {
+    if (src[i] !== "<") {
+      throw new Error(`parseAdNode: expected '<' at offset ${i}`);
+    }
+    i++;
+    const tagName = readTagName();
+    skipWs();
+    while (i < src.length && src[i] !== ">") i++;
+    const selfClosing = src[i - 1] === "/";
+    i++; // consume '>'
+    if (selfClosing) {
+      return { tagName, textContent: "", children: [] };
+    }
+    const children = [];
+    let text = "";
+    while (i < src.length) {
+      if (src[i] === "<") {
+        if (src[i + 1] === "/") {
+          i += 2;
+          readTagName();
+          skipWs();
+          if (src[i] === ">") i++;
+          break;
+        }
+        children.push(parseElement());
+      } else {
+        text += src[i];
+        i++;
+      }
+    }
+    return { tagName, textContent: text, children };
+  }
+
+  skipWs();
+  return parseElement();
+}

--- a/tests/unit/calendar-codec.basic.test.mjs
+++ b/tests/unit/calendar-codec.basic.test.mjs
@@ -1,0 +1,131 @@
+// Round-trip tests for applicationDataToIcal against a real, captured
+// EAS <Add> payload (verbatim from a live Exchange Online test run) -
+// proves the harness works end to end before we use it to pin down bugs.
+
+import { test, beforeAll } from "vitest";
+import assert from "node:assert/strict";
+import "../support/webext-shim.mjs";
+import ICAL from "../../src/vendor/ical.min.js";
+import { applicationDataToIcal } from "../../src/modules/eas/calendar-codec.mjs";
+import { ensureLoaded } from "../../src/modules/eas/timezone-mapping.mjs";
+import { parseAdNode } from "../support/xml-node.mjs";
+
+beforeAll(() => ensureLoaded());
+
+// Captured live: kovo1@dgtfactory.com invites kovacik@dgtfactory.com to a
+// weekly recurring meeting, EAS 16.1, unresponded.
+const ADD_TEST24 = `<ApplicationData>
+  <AllDayEvent xmlns='Calendar'>0</AllDayEvent>
+  <TimeZone xmlns='Calendar'>xP%2F%2F%2F0MAZQBuAHQAcgBhAGwAIABFAHUAcgBvAHAAZQAgAFMAdABhAG4AZABhAHIAZAAgAFQAaQBtAGUAAAAAAAAAAAAAAAoAAAAFAAMAAAAAAAAAAAAAACgAVQBUAEMAKwAwADEAOgAwADAAKQAgAEIAZQBsAGcAcgBhAGQAZQAsACAAQgByAGEAdABpAHMAbABhAHYAYQAAAAMAAAAFAAIAAAAAAAAAxP%2F%2F%2Fw%3D%3D</TimeZone>
+  <DtStamp xmlns='Calendar'>20260731T163448Z</DtStamp>
+  <StartTime xmlns='Calendar'>20260731T133000Z</StartTime>
+  <Subject xmlns='Calendar'>test24</Subject>
+  <UID xmlns='Calendar'>040000008200E00074C5B7101A82E00800000000E9ABA67E0A21DD01000000000000000010000000977A7C48535D7E4BB962D5FAB0E784A9</UID>
+  <OrganizerName xmlns='Calendar'>test%20kovo1</OrganizerName>
+  <OrganizerEmail xmlns='Calendar'>kovo1%40dgtfactory.com</OrganizerEmail>
+  <Attendees xmlns='Calendar'>
+    <Attendee xmlns='Calendar'>
+      <Email xmlns='Calendar'>kovacik%40dgtfactory.com</Email>
+      <Name xmlns='Calendar'>Tom%C3%83%C2%A1%C3%85%C2%A1%20Kov%C3%83%C2%A1%C3%84%C2%8Dik</Name>
+      <AttendeeType xmlns='Calendar'>1</AttendeeType>
+    </Attendee>
+  </Attendees>
+  <Location xmlns='AirSyncBase'/>
+  <EndTime xmlns='Calendar'>20260731T140000Z</EndTime>
+  <Recurrence xmlns='Calendar'>
+    <Type xmlns='Calendar'>1</Type>
+    <Interval xmlns='Calendar'>1</Interval>
+    <Until xmlns='Calendar'>20270122T143000Z</Until>
+    <DayOfWeek xmlns='Calendar'>32</DayOfWeek>
+    <FirstDayOfWeek xmlns='Calendar'>0</FirstDayOfWeek>
+  </Recurrence>
+  <Sensitivity xmlns='Calendar'>0</Sensitivity>
+  <BusyStatus xmlns='Calendar'>1</BusyStatus>
+  <Reminder xmlns='Calendar'>15</Reminder>
+  <MeetingStatus xmlns='Calendar'>3</MeetingStatus>
+  <NativeBodyType xmlns='AirSyncBase'>2</NativeBodyType>
+  <ResponseRequested xmlns='Calendar'>1</ResponseRequested>
+  <ResponseType xmlns='Calendar'>5</ResponseType>
+</ApplicationData>`;
+
+function masterVevent(icalString) {
+  const vcal = new ICAL.Component(ICAL.parse(icalString));
+  return vcal
+    .getAllSubcomponents("vevent")
+    .find((v) => !v.getFirstProperty("recurrence-id"));
+}
+
+test("applicationDataToIcal: fresh Add maps Subject/Organizer/Attendee/times", () => {
+  const adNode = parseAdNode(ADD_TEST24);
+  const icalString = applicationDataToIcal({
+    adNode,
+    existingIcal: null,
+    serverID: "server-id-1",
+    asVersion: "16.1",
+    defaultTimezone: "UTC",
+    syncRecurrence: true,
+    uid: null,
+    userEmail: "kovacik@dgtfactory.com",
+  });
+
+  const vevent = masterVevent(icalString);
+  assert.ok(vevent, "expected a master VEVENT with no RECURRENCE-ID");
+  assert.equal(vevent.getFirstPropertyValue("summary"), "test24");
+
+  const organizer = vevent.getFirstProperty("organizer");
+  assert.ok(organizer, "expected an ORGANIZER property");
+  assert.equal(organizer.getFirstValue(), "mailto:kovo1@dgtfactory.com");
+  assert.equal(organizer.getParameter("cn"), "test kovo1");
+
+  const attendees = vevent.getAllProperties("attendee");
+  assert.equal(attendees.length, 1);
+  assert.equal(attendees[0].getFirstValue(), "mailto:kovacik@dgtfactory.com");
+
+  const dtstart = vevent.getFirstPropertyValue("dtstart");
+  assert.equal(dtstart.toString(), "2026-07-31T13:30:00Z");
+
+  assert.ok(
+    vevent.getFirstPropertyValue("rrule"),
+    "expected an RRULE from the Recurrence block",
+  );
+});
+
+test("applicationDataToIcal: a delta-only Change (DtStamp only) leaves other fields untouched", () => {
+  const first = applicationDataToIcal({
+    adNode: parseAdNode(ADD_TEST24),
+    existingIcal: null,
+    serverID: "server-id-1",
+    asVersion: "16.1",
+    defaultTimezone: "UTC",
+    syncRecurrence: true,
+    uid: null,
+    userEmail: "kovacik@dgtfactory.com",
+  });
+
+  const deltaOnly = parseAdNode(
+    `<ApplicationData><DtStamp xmlns='Calendar'>20260731T170000Z</DtStamp></ApplicationData>`,
+  );
+  const second = applicationDataToIcal({
+    adNode: deltaOnly,
+    existingIcal: first,
+    serverID: "server-id-1",
+    asVersion: "16.1",
+    defaultTimezone: "UTC",
+    syncRecurrence: true,
+    uid: null,
+    userEmail: "kovacik@dgtfactory.com",
+  });
+
+  const vevent = masterVevent(second);
+  assert.equal(
+    vevent.getFirstPropertyValue("summary"),
+    "test24",
+    "Subject should survive a delta that doesn't mention it",
+  );
+  const organizer = vevent.getFirstProperty("organizer");
+  assert.equal(
+    organizer?.getFirstValue(),
+    "mailto:kovo1@dgtfactory.com",
+    "Organizer should survive a delta that doesn't mention it",
+  );
+});

--- a/tests/unit/calendar-codec.embedded-exceptions.test.mjs
+++ b/tests/unit/calendar-codec.embedded-exceptions.test.mjs
@@ -1,0 +1,242 @@
+// The 2.5/14.x embedded <Exceptions> path - appendInboundExceptions'
+// <Deleted>1</Deleted> handling and appendOutboundExceptions - as
+// opposed to the 16.1 standalone-<Change> path already covered by
+// calendar-codec.inbound-edits.test.mjs / outbound-edits.test.mjs
+// (applyInstanceChange/applyInstanceDelete/appendInstanceChanges).
+// Genuinely untested before this file (see TEST-PLAN.md's coverage
+// matrix). Also what Exchange sends for occurrence deletes even
+// against a 16.1 account when the delete happens via OWA, per live
+// cross-checks during the jobisoft#334 investigation - so despite the
+// "2.5/14.x" label, this shape shows up inbound on modern accounts too.
+
+import { test, beforeAll } from "vitest";
+import assert from "node:assert/strict";
+import "../support/webext-shim.mjs";
+import ICAL from "../../src/vendor/ical.min.js";
+import { applicationDataToIcal, appendApplicationDataFromIcal } from "../../src/modules/eas/calendar-codec.mjs";
+import { createWBXML, decodeWBXML } from "../../src/modules/wbxml.mjs";
+import { ensureLoaded } from "../../src/modules/eas/timezone-mapping.mjs";
+import { parseAdNode } from "../support/xml-node.mjs";
+import { readPathFrom } from "../../src/modules/eas/wbxml-helpers.mjs";
+
+beforeAll(() => ensureLoaded());
+
+const COMMON = {
+  serverID: "server-id-embedded",
+  defaultTimezone: "UTC",
+  syncRecurrence: true,
+  uid: null,
+  userEmail: "kovacik@dgtfactory.com",
+};
+
+const ADD_RECURRING_SERIES = `<ApplicationData>
+  <AllDayEvent xmlns='Calendar'>0</AllDayEvent>
+  <DtStamp xmlns='Calendar'>20260801T090000Z</DtStamp>
+  <StartTime xmlns='Calendar'>20260801T100000Z</StartTime>
+  <Subject xmlns='Calendar'>test-embedded-series</Subject>
+  <UID xmlns='Calendar'>0400-embedded-series-uid</UID>
+  <EndTime xmlns='Calendar'>20260801T103000Z</EndTime>
+  <Recurrence xmlns='Calendar'>
+    <Type xmlns='Calendar'>1</Type>
+    <Interval xmlns='Calendar'>1</Interval>
+    <Until xmlns='Calendar'>20261231T100000Z</Until>
+    <DayOfWeek xmlns='Calendar'>32</DayOfWeek>
+    <FirstDayOfWeek xmlns='Calendar'>0</FirstDayOfWeek>
+  </Recurrence>
+  <Sensitivity xmlns='Calendar'>0</Sensitivity>
+  <BusyStatus xmlns='Calendar'>2</BusyStatus>
+  <MeetingStatus xmlns='Calendar'>0</MeetingStatus>
+</ApplicationData>`;
+
+function masterVevent(icalString) {
+  const vcal = new ICAL.Component(ICAL.parse(icalString));
+  return vcal
+    .getAllSubcomponents("vevent")
+    .find((v) => !v.getFirstProperty("recurrence-id"));
+}
+function overrideByRecurrenceId(icalString, isoDate) {
+  const vcal = new ICAL.Component(ICAL.parse(icalString));
+  return vcal
+    .getAllSubcomponents("vevent")
+    .find((v) => v.getFirstPropertyValue("recurrence-id")?.toString() === isoDate);
+}
+
+/* ── Inbound ──────────────────────────────────────────────────────── */
+
+test("inbound: an embedded Exception identified by ExceptionStartTime (2.5/14.x, not InstanceId) with Deleted=1 adds an EXDATE", () => {
+  const afterAdd = applicationDataToIcal({
+    adNode: parseAdNode(ADD_RECURRING_SERIES),
+    existingIcal: null,
+    asVersion: "14.1",
+    ...COMMON,
+  });
+
+  const deleteException = parseAdNode(`<ApplicationData>
+    <Exceptions xmlns='Calendar'>
+      <Exception xmlns='Calendar'>
+        <ExceptionStartTime xmlns='Calendar'>20260808T100000Z</ExceptionStartTime>
+        <Deleted xmlns='Calendar'>1</Deleted>
+      </Exception>
+    </Exceptions>
+  </ApplicationData>`);
+
+  const afterDelete = applicationDataToIcal({
+    adNode: deleteException,
+    existingIcal: afterAdd,
+    asVersion: "14.1",
+    ...COMMON,
+  });
+
+  const master = masterVevent(afterDelete);
+  const exdates = master
+    .getAllProperties("exdate")
+    .map((p) => p.getFirstValue().toString());
+  assert.deepEqual(exdates, ["2026-08-08T10:00:00Z"]);
+  assert.equal(
+    overrideByRecurrenceId(afterDelete, "2026-08-08T10:00:00Z"),
+    undefined,
+    "a deleted instance must not also leave an override behind",
+  );
+});
+
+test("inbound: an embedded Exception without Deleted creates an override, keyed the same way as the InstanceId form", () => {
+  const afterAdd = applicationDataToIcal({
+    adNode: parseAdNode(ADD_RECURRING_SERIES),
+    existingIcal: null,
+    asVersion: "14.1",
+    ...COMMON,
+  });
+
+  const editException = parseAdNode(`<ApplicationData>
+    <Exceptions xmlns='Calendar'>
+      <Exception xmlns='Calendar'>
+        <ExceptionStartTime xmlns='Calendar'>20260808T100000Z</ExceptionStartTime>
+        <StartTime xmlns='Calendar'>20260808T140000Z</StartTime>
+        <EndTime xmlns='Calendar'>20260808T143000Z</EndTime>
+        <Subject xmlns='Calendar'>test-embedded-series (one occurrence moved)</Subject>
+      </Exception>
+    </Exceptions>
+  </ApplicationData>`);
+
+  const afterEdit = applicationDataToIcal({
+    adNode: editException,
+    existingIcal: afterAdd,
+    asVersion: "14.1",
+    ...COMMON,
+  });
+
+  const override = overrideByRecurrenceId(afterEdit, "2026-08-08T10:00:00Z");
+  assert.ok(override, "expected an override VEVENT for the edited occurrence");
+  assert.equal(
+    override.getFirstPropertyValue("summary"),
+    "test-embedded-series (one occurrence moved)",
+  );
+  assert.equal(
+    override.getFirstPropertyValue("dtstart").toString(),
+    "2026-08-08T14:00:00Z",
+  );
+});
+
+/* ── Outbound ─────────────────────────────────────────────────────── */
+
+function roundTripApplicationData(icalString, asVersion) {
+  const w = createWBXML("AirSync");
+  w.otag("ApplicationData");
+  appendApplicationDataFromIcal({
+    builder: w,
+    ical: icalString,
+    asVersion,
+    defaultTimezone: "UTC",
+    syncRecurrence: true,
+    userEmail: "kovacik@dgtfactory.com",
+  });
+  w.switchpage("AirSync");
+  w.ctag();
+  return parseAdNode(decodeWBXML(w.getBytes()));
+}
+
+test("outbound (14.1): a master with an EXDATE emits an EMBEDDED <Exceptions><Exception> inside the same ApplicationData, not a separate command", () => {
+  const seriesWithExdate = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:0400-embedded-outbound-uid
+DTSTAMP:20260801T090000Z
+DTSTART:20260801T100000Z
+DTEND:20260801T103000Z
+SUMMARY:test-embedded-outbound
+RRULE:FREQ=WEEKLY;INTERVAL=1;UNTIL=20261231T100000Z;BYDAY=SA
+EXDATE:20260808T100000Z
+END:VEVENT
+END:VCALENDAR
+`;
+
+  const node = roundTripApplicationData(seriesWithExdate, "14.1");
+  assert.equal(node.tagName, "ApplicationData");
+  const exceptions = node.children.find((c) => c.tagName === "Exceptions");
+  assert.ok(exceptions, "expected an embedded Exceptions wrapper");
+  const exception = exceptions.children.find((c) => c.tagName === "Exception");
+  assert.equal(
+    readPathFrom(exception, ["ExceptionStartTime"]),
+    "20260808T100000Z",
+  );
+  assert.equal(readPathFrom(exception, ["Deleted"]), "1");
+});
+
+test("outbound (14.1): a master with a RECURRENCE-ID override emits an embedded Exception carrying the override's own fields", () => {
+  const seriesWithOverride = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:0400-embedded-outbound-uid
+DTSTAMP:20260801T090000Z
+DTSTART:20260801T100000Z
+DTEND:20260801T103000Z
+SUMMARY:test-embedded-outbound
+RRULE:FREQ=WEEKLY;INTERVAL=1;UNTIL=20261231T100000Z;BYDAY=SA
+END:VEVENT
+BEGIN:VEVENT
+UID:0400-embedded-outbound-uid
+RECURRENCE-ID:20260808T100000Z
+DTSTAMP:20260801T090000Z
+DTSTART:20260808T140000Z
+DTEND:20260808T143000Z
+SUMMARY:test-embedded-outbound (moved)
+END:VEVENT
+END:VCALENDAR
+`;
+
+  const node = roundTripApplicationData(seriesWithOverride, "14.1");
+  const exceptions = node.children.find((c) => c.tagName === "Exceptions");
+  assert.ok(exceptions, "expected an embedded Exceptions wrapper");
+  const exception = exceptions.children.find((c) => c.tagName === "Exception");
+  assert.equal(
+    readPathFrom(exception, ["ExceptionStartTime"]),
+    "20260808T100000Z",
+  );
+  assert.equal(
+    readPathFrom(exception, ["Subject"]),
+    "test-embedded-outbound (moved)",
+  );
+  assert.equal(readPathFrom(exception, ["StartTime"]), "20260808T140000Z");
+});
+
+test("outbound (16.1): the same EXDATE/override data does NOT get an embedded Exceptions wrapper - 16.1 handles exceptions as separate <Change> commands at the orchestrator level (appendInstanceChanges), not inside ApplicationData", () => {
+  const seriesWithExdate = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:0400-embedded-outbound-uid
+DTSTAMP:20260801T090000Z
+DTSTART:20260801T100000Z
+DTEND:20260801T103000Z
+SUMMARY:test-embedded-outbound
+RRULE:FREQ=WEEKLY;INTERVAL=1;UNTIL=20261231T100000Z;BYDAY=SA
+EXDATE:20260808T100000Z
+END:VEVENT
+END:VCALENDAR
+`;
+
+  const node = roundTripApplicationData(seriesWithExdate, "16.1");
+  assert.equal(
+    node.children.find((c) => c.tagName === "Exceptions"),
+    undefined,
+  );
+});

--- a/tests/unit/calendar-codec.inbound-edits.test.mjs
+++ b/tests/unit/calendar-codec.inbound-edits.test.mjs
@@ -1,0 +1,205 @@
+// Inbound EAS -> iCal: edit/reschedule a single event, edit a whole
+// recurring series, and edit/delete a single occurrence within a series
+// (the 16.1 standalone per-instance <Change> path - applyInstanceChange/
+// applyInstanceDelete - as opposed to the embedded <Exceptions> path
+// already covered in calendar-codec.inbound-exceptions.test.mjs).
+
+import { test, beforeAll } from "vitest";
+import assert from "node:assert/strict";
+import "../support/webext-shim.mjs";
+import ICAL from "../../src/vendor/ical.min.js";
+import {
+  applicationDataToIcal,
+  applyInstanceChange,
+  applyInstanceDelete,
+} from "../../src/modules/eas/calendar-codec.mjs";
+import { ensureLoaded } from "../../src/modules/eas/timezone-mapping.mjs";
+import { parseAdNode } from "../support/xml-node.mjs";
+
+beforeAll(() => ensureLoaded());
+
+const COMMON = {
+  serverID: "server-id-1",
+  asVersion: "16.1",
+  defaultTimezone: "UTC",
+  syncRecurrence: true,
+  uid: null,
+  userEmail: "kovacik@dgtfactory.com",
+};
+
+const ADD_SINGLE_EVENT = `<ApplicationData>
+  <AllDayEvent xmlns='Calendar'>0</AllDayEvent>
+  <DtStamp xmlns='Calendar'>20260801T090000Z</DtStamp>
+  <StartTime xmlns='Calendar'>20260801T100000Z</StartTime>
+  <Subject xmlns='Calendar'>test-single</Subject>
+  <UID xmlns='Calendar'>0400-single-uid</UID>
+  <EndTime xmlns='Calendar'>20260801T103000Z</EndTime>
+  <Sensitivity xmlns='Calendar'>0</Sensitivity>
+  <BusyStatus xmlns='Calendar'>2</BusyStatus>
+  <MeetingStatus xmlns='Calendar'>0</MeetingStatus>
+</ApplicationData>`;
+
+function masterVevent(icalString) {
+  const vcal = new ICAL.Component(ICAL.parse(icalString));
+  return vcal
+    .getAllSubcomponents("vevent")
+    .find((v) => !v.getFirstProperty("recurrence-id"));
+}
+
+test("single event: a Change reschedules Start/End and edits Subject", () => {
+  const afterAdd = applicationDataToIcal({
+    adNode: parseAdNode(ADD_SINGLE_EVENT),
+    existingIcal: null,
+    ...COMMON,
+  });
+
+  const reschedule = parseAdNode(`<ApplicationData>
+    <StartTime xmlns='Calendar'>20260801T140000Z</StartTime>
+    <EndTime xmlns='Calendar'>20260801T143000Z</EndTime>
+    <Subject xmlns='Calendar'>test-single (moved)</Subject>
+  </ApplicationData>`);
+
+  const afterReschedule = applicationDataToIcal({
+    adNode: reschedule,
+    existingIcal: afterAdd,
+    ...COMMON,
+  });
+
+  const vevent = masterVevent(afterReschedule);
+  assert.equal(vevent.getFirstPropertyValue("summary"), "test-single (moved)");
+  assert.equal(
+    vevent.getFirstPropertyValue("dtstart").toString(),
+    "2026-08-01T14:00:00Z",
+  );
+  assert.equal(
+    vevent.getFirstPropertyValue("dtend").toString(),
+    "2026-08-01T14:30:00Z",
+  );
+});
+
+const ADD_RECURRING_SERIES = `<ApplicationData>
+  <AllDayEvent xmlns='Calendar'>0</AllDayEvent>
+  <DtStamp xmlns='Calendar'>20260801T090000Z</DtStamp>
+  <StartTime xmlns='Calendar'>20260801T100000Z</StartTime>
+  <Subject xmlns='Calendar'>test-series</Subject>
+  <UID xmlns='Calendar'>0400-series-uid</UID>
+  <EndTime xmlns='Calendar'>20260801T103000Z</EndTime>
+  <Recurrence xmlns='Calendar'>
+    <Type xmlns='Calendar'>1</Type>
+    <Interval xmlns='Calendar'>1</Interval>
+    <Until xmlns='Calendar'>20261231T100000Z</Until>
+    <DayOfWeek xmlns='Calendar'>32</DayOfWeek>
+    <FirstDayOfWeek xmlns='Calendar'>0</FirstDayOfWeek>
+  </Recurrence>
+  <Sensitivity xmlns='Calendar'>0</Sensitivity>
+  <BusyStatus xmlns='Calendar'>2</BusyStatus>
+  <MeetingStatus xmlns='Calendar'>0</MeetingStatus>
+</ApplicationData>`;
+
+test("whole series: a Change with a new Recurrence.Until shortens the RRULE", () => {
+  const afterAdd = applicationDataToIcal({
+    adNode: parseAdNode(ADD_RECURRING_SERIES),
+    existingIcal: null,
+    ...COMMON,
+  });
+
+  const shortened = parseAdNode(`<ApplicationData>
+    <Recurrence xmlns='Calendar'>
+      <Type xmlns='Calendar'>1</Type>
+      <Interval xmlns='Calendar'>1</Interval>
+      <Until xmlns='Calendar'>20260901T100000Z</Until>
+      <DayOfWeek xmlns='Calendar'>32</DayOfWeek>
+      <FirstDayOfWeek xmlns='Calendar'>0</FirstDayOfWeek>
+    </Recurrence>
+  </ApplicationData>`);
+
+  const afterChange = applicationDataToIcal({
+    adNode: shortened,
+    existingIcal: afterAdd,
+    ...COMMON,
+  });
+
+  const vevent = masterVevent(afterChange);
+  const rrule = vevent.getFirstPropertyValue("rrule");
+  assert.ok(rrule, "expected an RRULE");
+  assert.equal(rrule.until.toString(), "2026-09-01T10:00:00Z");
+});
+
+function overrideByRecurrenceId(icalString, isoDate) {
+  const vcal = new ICAL.Component(ICAL.parse(icalString));
+  return vcal
+    .getAllSubcomponents("vevent")
+    .find(
+      (v) =>
+        v.getFirstPropertyValue("recurrence-id")?.toString() === isoDate,
+    );
+}
+
+test("single occurrence (16.1 standalone Change): applyInstanceChange reschedules just that instance", () => {
+  const afterAdd = applicationDataToIcal({
+    adNode: parseAdNode(ADD_RECURRING_SERIES),
+    existingIcal: null,
+    ...COMMON,
+  });
+
+  // Second occurrence of the weekly series: 2026-08-08T10:00:00Z.
+  const instanceUtc = new Date("2026-08-08T10:00:00Z");
+  const occurrenceEdit = parseAdNode(`<ApplicationData>
+    <StartTime xmlns='Calendar'>20260808T130000Z</StartTime>
+    <EndTime xmlns='Calendar'>20260808T133000Z</EndTime>
+    <Subject xmlns='Calendar'>test-series (one occurrence moved)</Subject>
+  </ApplicationData>`);
+
+  const afterInstanceChange = applyInstanceChange({
+    ical: afterAdd,
+    adNode: occurrenceEdit,
+    instanceUtc,
+    asVersion: "16.1",
+    defaultTimezone: "UTC",
+    userEmail: "kovacik@dgtfactory.com",
+  });
+
+  const master = masterVevent(afterInstanceChange);
+  assert.equal(
+    master.getFirstPropertyValue("summary"),
+    "test-series",
+    "the master's own Subject must be untouched by an occurrence edit",
+  );
+
+  const override = overrideByRecurrenceId(
+    afterInstanceChange,
+    "2026-08-08T10:00:00Z",
+  );
+  assert.ok(override, "expected an override VEVENT for the edited occurrence");
+  assert.equal(
+    override.getFirstPropertyValue("summary"),
+    "test-series (one occurrence moved)",
+  );
+  assert.equal(
+    override.getFirstPropertyValue("dtstart").toString(),
+    "2026-08-08T13:00:00Z",
+  );
+});
+
+test("single occurrence (16.1 standalone Change): applyInstanceDelete adds an EXDATE and drops any override", () => {
+  const afterAdd = applicationDataToIcal({
+    adNode: parseAdNode(ADD_RECURRING_SERIES),
+    existingIcal: null,
+    ...COMMON,
+  });
+
+  const instanceUtc = new Date("2026-08-08T10:00:00Z");
+  const afterDelete = applyInstanceDelete({ ical: afterAdd, instanceUtc });
+
+  const master = masterVevent(afterDelete);
+  const exdates = master
+    .getAllProperties("exdate")
+    .map((p) => p.getFirstValue().toString());
+  assert.deepEqual(exdates, ["2026-08-08T10:00:00Z"]);
+
+  assert.equal(
+    overrideByRecurrenceId(afterDelete, "2026-08-08T10:00:00Z"),
+    undefined,
+    "a deleted instance must not also leave a stale override behind",
+  );
+});

--- a/tests/unit/calendar-codec.inbound-exceptions.test.mjs
+++ b/tests/unit/calendar-codec.inbound-exceptions.test.mjs
@@ -1,0 +1,198 @@
+// Characterization tests for jobisoft#342: a recurrence exception that
+// arrives as a status-only delta (Exchange doesn't repeat a field that
+// hasn't changed since the exception's first sighting) loses that field
+// locally instead of inheriting it, because `appendInboundExceptions`
+// rebuilds each override VEVENT from an empty component every time an
+// `<Exceptions>` block appears, with no fallback to the master's or the
+// prior override's values.
+//
+// These tests assert TODAY'S (buggy) behavior on purpose - see
+// TEST-PLAN.md. They exist so a fix for #342 is forced to touch this
+// file (the assertions below will start failing) rather than silently
+// landing unverified. Flip `todo: true` back off and update the
+// assertions to the correct/expected values once the fix lands.
+
+import { test, beforeAll } from "vitest";
+import assert from "node:assert/strict";
+import "../support/webext-shim.mjs";
+import ICAL from "../../src/vendor/ical.min.js";
+import { applicationDataToIcal } from "../../src/modules/eas/calendar-codec.mjs";
+import { ensureLoaded } from "../../src/modules/eas/timezone-mapping.mjs";
+import { parseAdNode } from "../support/xml-node.mjs";
+
+beforeAll(() => ensureLoaded());
+
+const ADD_TEST35 = `<ApplicationData>
+  <AllDayEvent xmlns='Calendar'>0</AllDayEvent>
+  <DtStamp xmlns='Calendar'>20260731T182049Z</DtStamp>
+  <StartTime xmlns='Calendar'>20260807T060000Z</StartTime>
+  <Subject xmlns='Calendar'>test35</Subject>
+  <UID xmlns='Calendar'>0400-test35-uid</UID>
+  <OrganizerName xmlns='Calendar'>Tomas%20Kovacik</OrganizerName>
+  <OrganizerEmail xmlns='Calendar'>tomas.kovacik%40dxc-tech.sk</OrganizerEmail>
+  <Attendees xmlns='Calendar'>
+    <Attendee xmlns='Calendar'>
+      <Email xmlns='Calendar'>kovacik%40dgtfactory.com</Email>
+      <AttendeeType xmlns='Calendar'>1</AttendeeType>
+    </Attendee>
+  </Attendees>
+  <EndTime xmlns='Calendar'>20260807T063000Z</EndTime>
+  <Recurrence xmlns='Calendar'>
+    <Type xmlns='Calendar'>1</Type>
+    <Interval xmlns='Calendar'>1</Interval>
+    <Until xmlns='Calendar'>20270122T200000Z</Until>
+    <DayOfWeek xmlns='Calendar'>32</DayOfWeek>
+    <FirstDayOfWeek xmlns='Calendar'>0</FirstDayOfWeek>
+  </Recurrence>
+  <Sensitivity xmlns='Calendar'>0</Sensitivity>
+  <BusyStatus xmlns='Calendar'>2</BusyStatus>
+  <Reminder xmlns='Calendar'>15</Reminder>
+  <MeetingStatus xmlns='Calendar'>3</MeetingStatus>
+  <ResponseType xmlns='Calendar'>3</ResponseType>
+</ApplicationData>`;
+
+// First sighting of the 2026-08-07 occurrence's exception: full fields,
+// including Subject - exactly what Exchange sends the first time.
+const CHANGE_FIRST_EXCEPTION = `<ApplicationData>
+  <Exceptions xmlns='Calendar'>
+    <Exception xmlns='Calendar'>
+      <InstanceId xmlns='AirSyncBase'>20260807T060000Z</InstanceId>
+      <StartTime xmlns='Calendar'>20260807T060000Z</StartTime>
+      <Subject xmlns='Calendar'>Canceled%3A%20test35</Subject>
+      <EndTime xmlns='Calendar'>20260807T063000Z</EndTime>
+      <BusyStatus xmlns='Calendar'>0</BusyStatus>
+      <MeetingStatus xmlns='Calendar'>7</MeetingStatus>
+    </Exception>
+  </Exceptions>
+</ApplicationData>`;
+
+// Second touch of the SAME instance (e.g. the whole series then also
+// gets cancelled): Exchange only resends what changed. Subject is
+// unchanged since the first sighting, so it's omitted here - this is
+// the real, captured shape of the delta that triggers #342.
+const CHANGE_SECOND_TOUCH_DROPS_SUBJECT = `<ApplicationData>
+  <Exceptions xmlns='Calendar'>
+    <Exception xmlns='Calendar'>
+      <InstanceId xmlns='AirSyncBase'>20260807T060000Z</InstanceId>
+      <StartTime xmlns='Calendar'>20260807T060000Z</StartTime>
+      <EndTime xmlns='Calendar'>20260807T063000Z</EndTime>
+      <MeetingStatus xmlns='Calendar'>7</MeetingStatus>
+    </Exception>
+  </Exceptions>
+</ApplicationData>`;
+
+function overrideVevent(icalString) {
+  const vcal = new ICAL.Component(ICAL.parse(icalString));
+  return vcal
+    .getAllSubcomponents("vevent")
+    .find((v) => v.getFirstProperty("recurrence-id"));
+}
+
+test(
+  "jobisoft#342: a second, status-only touch of an exception drops its Subject instead of inheriting it",
+  () => {
+    const commonArgs = {
+      serverID: "server-id-test35",
+      asVersion: "16.1",
+      defaultTimezone: "UTC",
+      syncRecurrence: true,
+      uid: null,
+      userEmail: "kovacik@dgtfactory.com",
+    };
+
+    const afterAdd = applicationDataToIcal({
+      adNode: parseAdNode(ADD_TEST35),
+      existingIcal: null,
+      ...commonArgs,
+    });
+
+    const afterFirstException = applicationDataToIcal({
+      adNode: parseAdNode(CHANGE_FIRST_EXCEPTION),
+      existingIcal: afterAdd,
+      ...commonArgs,
+    });
+
+    // Sanity check: the exception's first sighting DOES carry the title.
+    const firstOverride = overrideVevent(afterFirstException);
+    assert.equal(
+      firstOverride.getFirstPropertyValue("summary"),
+      "Canceled: test35",
+      "first sighting of the exception should carry its own Subject",
+    );
+
+    const afterSecondTouch = applicationDataToIcal({
+      adNode: parseAdNode(CHANGE_SECOND_TOUCH_DROPS_SUBJECT),
+      existingIcal: afterFirstException,
+      ...commonArgs,
+    });
+
+    const secondOverride = overrideVevent(afterSecondTouch);
+    assert.ok(secondOverride, "expected the override VEVENT to still exist");
+
+    // BUG (jobisoft#342): this should still read "Canceled: test35"
+    // (inherited from the prior override / master), but today it comes
+    // back null because appendInboundExceptions rebuilds the override
+    // from an empty component and populateVeventFromAd only sets SUMMARY
+    // when the update's XML actually mentions <Subject>.
+    assert.equal(
+      secondOverride.getFirstPropertyValue("summary"),
+      null,
+      "documents jobisoft#342: title is lost on the second, status-only touch",
+    );
+  },
+);
+
+// The sparsest real-world variant, captured live: an occurrence with no
+// prior per-instance touch at all gets a bare status-only exception
+// (e.g. the whole series is cancelled, and this occurrence's own
+// exception has never been separately established before) - InstanceId
+// and MeetingStatus only, no StartTime/EndTime/Subject/DtStamp
+// whatsoever. Same root cause as above, but the resulting override has
+// no DTSTART/DTEND either, not just no title.
+const CHANGE_BARE_EXCEPTION = `<ApplicationData>
+  <Exceptions xmlns='Calendar'>
+    <Exception xmlns='Calendar'>
+      <InstanceId xmlns='AirSyncBase'>20260814T060000Z</InstanceId>
+      <Location xmlns='AirSyncBase'/>
+      <MeetingStatus xmlns='Calendar'>7</MeetingStatus>
+    </Exception>
+  </Exceptions>
+</ApplicationData>`;
+
+test(
+  "jobisoft#342 (sparsest variant): a bare status-only exception with no prior touch has no DTSTART/DTEND/SUMMARY at all",
+  () => {
+    const commonArgs = {
+      serverID: "server-id-test35",
+      asVersion: "16.1",
+      defaultTimezone: "UTC",
+      syncRecurrence: true,
+      uid: null,
+      userEmail: "kovacik@dgtfactory.com",
+    };
+
+    const afterAdd = applicationDataToIcal({
+      adNode: parseAdNode(ADD_TEST35),
+      existingIcal: null,
+      ...commonArgs,
+    });
+
+    const afterBareException = applicationDataToIcal({
+      adNode: parseAdNode(CHANGE_BARE_EXCEPTION),
+      existingIcal: afterAdd,
+      ...commonArgs,
+    });
+
+    const override = overrideVevent(afterBareException);
+    assert.ok(override, "expected an override VEVENT for the instance");
+
+    // BUG (jobisoft#342): all three should inherit from the master
+    // (SUMMARY: "test35", DTSTART/DTEND: the occurrence's own computed
+    // time from the RRULE), but today all three are simply absent -
+    // appendInboundExceptions seeds the override from an empty
+    // component and nothing in this delta mentions any of them.
+    assert.equal(override.getFirstPropertyValue("summary"), null);
+    assert.equal(override.getFirstPropertyValue("dtstart"), null);
+    assert.equal(override.getFirstPropertyValue("dtend"), null);
+  },
+);

--- a/tests/unit/calendar-codec.outbound-edits.test.mjs
+++ b/tests/unit/calendar-codec.outbound-edits.test.mjs
@@ -1,0 +1,301 @@
+// Outbound iCal -> EAS: edit/reschedule a single event, edit a whole
+// recurring series' RRULE, and the 16.1 single-occurrence shape
+// (appendInstanceChanges) - the exact wire shape at the center of
+// jobisoft#334 (Exchange rejects it; see TEST-PLAN.md / project memory).
+//
+// These round-trip through the REAL WBXML encoder (wbxml.mjs's
+// createWBXML) and the REAL decoder (decodeWBXML) - no mocking, this
+// exercises the actual wire format, not just the codec's internal
+// intent.
+
+import { test, beforeAll } from "vitest";
+import assert from "node:assert/strict";
+import "../support/webext-shim.mjs";
+import {
+  appendApplicationDataFromIcal,
+  appendInstanceChanges,
+} from "../../src/modules/eas/calendar-codec.mjs";
+import { createWBXML, decodeWBXML } from "../../src/modules/wbxml.mjs";
+import { ensureLoaded } from "../../src/modules/eas/timezone-mapping.mjs";
+import { parseAdNode } from "../support/xml-node.mjs";
+import { readPathFrom } from "../../src/modules/eas/wbxml-helpers.mjs";
+
+beforeAll(() => ensureLoaded());
+
+const SINGLE_EVENT_ICS = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:0400-outbound-single-uid
+DTSTAMP:20260801T090000Z
+DTSTART:20260801T140000Z
+DTEND:20260801T143000Z
+SUMMARY:test-outbound-single (moved)
+END:VEVENT
+END:VCALENDAR
+`;
+
+/** Wraps a codec append call the same way sync-runner.mjs's
+ *  appendCommands does for a <Change>: <ApplicationData> ... </>,
+ *  switch back to AirSync, close. Returns the decoded node for the
+ *  <ApplicationData> element so callers can readPathFrom it directly. */
+function roundTripApplicationData(appendFn) {
+  const w = createWBXML("AirSync");
+  w.otag("ApplicationData");
+  appendFn(w);
+  w.switchpage("AirSync");
+  w.ctag();
+  const xml = decodeWBXML(w.getBytes());
+  return parseAdNode(xml);
+}
+
+/** Parses the codec's own YYYYMMDDTHHMMSSZ ("basic UTC") format. */
+function parseBasicUtc(s) {
+  const m = /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z$/.exec(s);
+  if (!m) throw new Error(`not a basic-UTC timestamp: ${s}`);
+  const [, y, mo, d, h, mi, se] = m.map(Number);
+  return new Date(Date.UTC(y, mo - 1, d, h, mi, se));
+}
+
+test(
+  "a VEVENT with no DTSTART/DTEND (the #342 corrupted-override shape) " +
+    "gets pushed with StartTime==EndTime==now(), not omitted",
+  () => {
+    // No DTSTART/DTEND at all - exactly what #342's sparsest variant
+    // leaves an override with (see calendar-codec.inbound-exceptions
+    // .test.mjs). This is the malformed shape that got rejected with a
+    // top-level Status 4 in the live log tonight.
+    const noStartEndIcs = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:0400-outbound-no-start-end-uid
+SUMMARY:
+END:VEVENT
+END:VCALENDAR
+`;
+
+    const before = new Date();
+    const node = roundTripApplicationData((w) =>
+      appendApplicationDataFromIcal({
+        builder: w,
+        ical: noStartEndIcs,
+        asVersion: "16.1",
+        defaultTimezone: "UTC",
+        syncRecurrence: false,
+        userEmail: "kovacik@dgtfactory.com",
+      }),
+    );
+    const after = new Date();
+
+    const startTime = parseBasicUtc(readPathFrom(node, ["StartTime"]));
+    const endTime = parseBasicUtc(readPathFrom(node, ["EndTime"]));
+
+    assert.equal(startTime.getTime(), endTime.getTime());
+    assert.ok(
+      startTime.getTime() >= before.getTime() - 1000 &&
+        startTime.getTime() <= after.getTime() + 1000,
+      `expected StartTime (${startTime.toISOString()}) to be close to ` +
+        `now (test ran ${before.toISOString()} - ${after.toISOString()})`,
+    );
+  },
+);
+
+test("single event: appendApplicationDataFromIcal emits the rescheduled Start/End/Subject", () => {
+  const node = roundTripApplicationData((w) =>
+    appendApplicationDataFromIcal({
+      builder: w,
+      ical: SINGLE_EVENT_ICS,
+      asVersion: "16.1",
+      defaultTimezone: "UTC",
+      syncRecurrence: false,
+      userEmail: "kovacik@dgtfactory.com",
+    }),
+  );
+
+  assert.equal(
+    readPathFrom(node, ["Subject"]),
+    "test-outbound-single (moved)",
+  );
+  assert.equal(readPathFrom(node, ["StartTime"]), "20260801T140000Z");
+  assert.equal(readPathFrom(node, ["EndTime"]), "20260801T143000Z");
+});
+
+test(
+  "16.1 Organizer-emission gate: OrganizerName/OrganizerEmail are never " +
+    "emitted outbound on 16.1, even though a real 16.1 <Add> DOES carry " +
+    "them inbound (see calendar-codec.basic.test.mjs)",
+  () => {
+    const withOrganizerIcs = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:0400-outbound-organizer-uid
+DTSTAMP:20260801T090000Z
+DTSTART:20260801T140000Z
+DTEND:20260801T143000Z
+SUMMARY:test-outbound-organizer
+ORGANIZER;CN=test kovo1:mailto:kovo1@dgtfactory.com
+END:VEVENT
+END:VCALENDAR
+`;
+
+    const node16_1 = roundTripApplicationData((w) =>
+      appendApplicationDataFromIcal({
+        builder: w,
+        ical: withOrganizerIcs,
+        asVersion: "16.1",
+        defaultTimezone: "UTC",
+        syncRecurrence: false,
+        userEmail: "kovacik@dgtfactory.com",
+      }),
+    );
+    assert.equal(readPathFrom(node16_1, ["OrganizerEmail"]), null);
+    assert.equal(readPathFrom(node16_1, ["OrganizerName"]), null);
+
+    // Contrast: on <=14.x the same local ORGANIZER IS emitted - confirms
+    // the gate is asVersion-specific, not a blanket "never emit" bug.
+    const node14_1 = roundTripApplicationData((w) =>
+      appendApplicationDataFromIcal({
+        builder: w,
+        ical: withOrganizerIcs,
+        asVersion: "14.1",
+        defaultTimezone: "UTC",
+        syncRecurrence: false,
+        userEmail: "kovacik@dgtfactory.com",
+      }),
+    );
+    assert.equal(readPathFrom(node14_1, ["OrganizerEmail"]), "kovo1@dgtfactory.com");
+    assert.equal(readPathFrom(node14_1, ["OrganizerName"]), "test kovo1");
+  },
+);
+
+const RECURRING_SERIES_ICS = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:0400-outbound-series-uid
+DTSTAMP:20260801T090000Z
+DTSTART:20260801T100000Z
+DTEND:20260801T103000Z
+SUMMARY:test-outbound-series
+RRULE:FREQ=WEEKLY;INTERVAL=1;UNTIL=20260901T100000Z;BYDAY=SA
+END:VEVENT
+END:VCALENDAR
+`;
+
+test("whole series: appendApplicationDataFromIcal emits a Recurrence block for the RRULE", () => {
+  const node = roundTripApplicationData((w) =>
+    appendApplicationDataFromIcal({
+      builder: w,
+      ical: RECURRING_SERIES_ICS,
+      asVersion: "16.1",
+      defaultTimezone: "UTC",
+      syncRecurrence: true,
+      userEmail: "kovacik@dgtfactory.com",
+    }),
+  );
+
+  assert.equal(readPathFrom(node, ["Recurrence", "Type"]), "1");
+  assert.equal(readPathFrom(node, ["Recurrence", "Interval"]), "1");
+  assert.equal(readPathFrom(node, ["Recurrence", "Until"]), "20260901T100000Z");
+});
+
+test(
+  "jobisoft#334: 16.1 single-occurrence delete is emitted as a standalone " +
+    "<Change> sharing the master's ServerId - the exact shape Exchange " +
+    "rejects (Status 6), confirmed live; not yet fixed",
+  () => {
+    const seriesWithExdate = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:0400-outbound-series-uid
+DTSTAMP:20260801T090000Z
+DTSTART:20260801T100000Z
+DTEND:20260801T103000Z
+SUMMARY:test-outbound-series
+RRULE:FREQ=WEEKLY;INTERVAL=1;UNTIL=20260901T100000Z;BYDAY=SA
+EXDATE:20260808T100000Z
+END:VEVENT
+END:VCALENDAR
+`;
+
+    const w = createWBXML("AirSync");
+    appendInstanceChanges({
+      builder: w,
+      blob: seriesWithExdate,
+      serverID: "server-id-series",
+      asVersion: "16.1",
+      defaultTimezone: "UTC",
+      syncRecurrence: true,
+      userEmail: "kovacik@dgtfactory.com",
+    });
+    const xml = decodeWBXML(w.getBytes());
+    const changeNode = parseAdNode(xml);
+
+    assert.equal(changeNode.tagName, "Change");
+    // Same ServerId as the master's own <Change> - this is exactly the
+    // "shares the master's ServerId" shape #334's root-cause writeup
+    // describes, kept as-is here (not split into a separate Sync
+    // request) because appendInstanceChanges only emits the <Change>
+    // command itself; request-level bundling is sync-runner.mjs's job.
+    assert.equal(readPathFrom(changeNode, ["ServerId"]), "server-id-series");
+    const ad = changeNode.children.find((c) => c.tagName === "ApplicationData");
+    assert.equal(readPathFrom(ad, ["InstanceId"]), "20260808T100000Z");
+    assert.equal(readPathFrom(ad, ["Deleted"]), "1");
+  },
+);
+
+test(
+  "jobisoft#334: 16.1 single-occurrence EDIT (not delete) is also a " +
+    "standalone <Change> sharing the master's ServerId - same shape, " +
+    "same unresolved rejection risk",
+  () => {
+    // Master + one RECURRENCE-ID override representing an edited (not
+    // deleted) occurrence - appendInstanceChanges' "overrides" branch,
+    // untested until now (only its "exdates" branch was covered above).
+    const seriesWithOverride = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:0400-outbound-series-uid
+DTSTAMP:20260801T090000Z
+DTSTART:20260801T100000Z
+DTEND:20260801T103000Z
+SUMMARY:test-outbound-series
+RRULE:FREQ=WEEKLY;INTERVAL=1;UNTIL=20260901T100000Z;BYDAY=SA
+END:VEVENT
+BEGIN:VEVENT
+UID:0400-outbound-series-uid
+RECURRENCE-ID:20260808T100000Z
+DTSTAMP:20260801T090000Z
+DTSTART:20260808T140000Z
+DTEND:20260808T143000Z
+SUMMARY:test-outbound-series (one occurrence moved)
+END:VEVENT
+END:VCALENDAR
+`;
+
+    const w = createWBXML("AirSync");
+    appendInstanceChanges({
+      builder: w,
+      blob: seriesWithOverride,
+      serverID: "server-id-series",
+      asVersion: "16.1",
+      defaultTimezone: "UTC",
+      syncRecurrence: true,
+      userEmail: "kovacik@dgtfactory.com",
+    });
+    const xml = decodeWBXML(w.getBytes());
+    const changeNode = parseAdNode(xml);
+
+    assert.equal(changeNode.tagName, "Change");
+    assert.equal(readPathFrom(changeNode, ["ServerId"]), "server-id-series");
+    const ad = changeNode.children.find((c) => c.tagName === "ApplicationData");
+    assert.equal(readPathFrom(ad, ["InstanceId"]), "20260808T100000Z");
+    assert.equal(
+      readPathFrom(ad, ["Subject"]),
+      "test-outbound-series (one occurrence moved)",
+    );
+    assert.equal(readPathFrom(ad, ["StartTime"]), "20260808T140000Z");
+    // isException:true suppresses Organizer/Recurrence re-emission on the
+    // override body - confirm that suppression is actually happening
+    // rather than silently duplicating the master's own fields here.
+    assert.equal(readPathFrom(ad, ["Recurrence", "Type"]), null);
+  },
+);

--- a/tests/unit/contact-codec.test.mjs
+++ b/tests/unit/contact-codec.test.mjs
@@ -1,0 +1,141 @@
+// contact-codec.mjs: EAS Contacts <-> vCard 4.0. A representative
+// slice, not exhaustive - the module maps a large number of individual
+// fields (prefixed phones, four Custom slots, half a dozen pass-through
+// properties); this covers name/email/phone/organization plus the
+// serverID/merge-aware/outbound mechanics shared by all of them, which
+// is where a regression is most likely to actually bite. Extending
+// field-by-field coverage is listed as open work in TEST-PLAN.md.
+
+import { test } from "vitest";
+import "../support/webext-shim.mjs";
+import ICAL from "../../src/vendor/ical.min.js";
+import assert from "node:assert/strict";
+import {
+  applicationDataToVCard,
+  appendApplicationDataFromVCard,
+  readEasServerIdFromVCard,
+  stampEasServerId,
+} from "../../src/modules/eas/contact-codec.mjs";
+import { createWBXML, decodeWBXML } from "../../src/modules/wbxml.mjs";
+import { parseAdNode } from "../support/xml-node.mjs";
+import { readPathFrom } from "../../src/modules/eas/wbxml-helpers.mjs";
+
+const ADD_CONTACT = `<ApplicationData>
+  <FirstName xmlns='Contacts'>Tomas</FirstName>
+  <LastName xmlns='Contacts'>Kovacik</LastName>
+  <Email1Address xmlns='Contacts'>Tomas%20Kovacik%20%3Ckovacik%40dgtfactory.com%3E</Email1Address>
+  <BusinessPhoneNumber xmlns='Contacts'>00421907813840</BusinessPhoneNumber>
+  <CompanyName xmlns='Contacts'>DGT%20factory%2C%20a.%20s.</CompanyName>
+  <JobTitle xmlns='Contacts'>President%20of%20space</JobTitle>
+</ApplicationData>`;
+
+test("applicationDataToVCard: maps Name/Email/Phone/Organization/JobTitle and stamps the ServerId", async () => {
+  const vcard = await applicationDataToVCard({
+    adNode: parseAdNode(ADD_CONTACT),
+    existingVcard: null,
+    serverID: "server-id-contact-1",
+    asVersion: "16.1",
+    separator: ",",
+    uid: null,
+  });
+
+  const comp = new ICAL.Component(ICAL.parse(vcard));
+  assert.deepEqual(comp.getFirstPropertyValue("n"), [
+    "Kovacik",
+    "Tomas",
+    "",
+    "",
+    "",
+  ]);
+  assert.equal(comp.getFirstPropertyValue("email"), "kovacik@dgtfactory.com");
+  const tel = comp.getFirstProperty("tel");
+  assert.equal(tel.getFirstValue(), "00421907813840");
+  assert.equal(tel.getParameter("type"), "work");
+  assert.deepEqual(comp.getFirstPropertyValue("org"), "DGT factory, a. s.");
+  assert.equal(comp.getFirstPropertyValue("title"), "President of space");
+  assert.equal(readEasServerIdFromVCard(vcard), "server-id-contact-1");
+});
+
+test("applicationDataToVCard: Name is merge-aware - a delta with no name tags leaves the existing N property untouched", async () => {
+  const afterAdd = await applicationDataToVCard({
+    adNode: parseAdNode(ADD_CONTACT),
+    existingVcard: null,
+    serverID: "server-id-contact-1",
+    asVersion: "16.1",
+    separator: ",",
+    uid: null,
+  });
+
+  const afterPhoneOnlyChange = await applicationDataToVCard({
+    adNode: parseAdNode(
+      `<ApplicationData><MobilePhoneNumber xmlns='Contacts'>00421900000000</MobilePhoneNumber></ApplicationData>`,
+    ),
+    existingVcard: afterAdd,
+    serverID: "server-id-contact-1",
+    asVersion: "16.1",
+    separator: ",",
+    uid: null,
+  });
+
+  const comp = new ICAL.Component(ICAL.parse(afterPhoneOnlyChange));
+  assert.deepEqual(comp.getFirstPropertyValue("n"), [
+    "Kovacik",
+    "Tomas",
+    "",
+    "",
+    "",
+  ]);
+  // Phones ARE merge-aware too, but at the whole-set level (any phone
+  // tag present reasserts the complete set) - so BusinessPhoneNumber
+  // from the original Add is gone now, replaced by just the Mobile one
+  // this delta carries. That's the documented behavior, not a bug.
+  const tels = comp.getAllProperties("tel");
+  assert.equal(tels.length, 1);
+  assert.equal(tels[0].getFirstValue(), "00421900000000");
+});
+
+test("stampEasServerId / readEasServerIdFromVCard round-trip", async () => {
+  const vcard = await applicationDataToVCard({
+    adNode: parseAdNode(ADD_CONTACT),
+    existingVcard: null,
+    serverID: "original-id",
+    asVersion: "16.1",
+    separator: ",",
+    uid: null,
+  });
+  const restamped = stampEasServerId(vcard, "new-id");
+  assert.equal(readEasServerIdFromVCard(restamped), "new-id");
+});
+
+test("appendApplicationDataFromVCard: outbound round-trip via the real WBXML encoder/decoder", () => {
+  const vcard = [
+    "BEGIN:VCARD",
+    "VERSION:4.0",
+    "N:Kovacik;Tomas;;;",
+    "EMAIL:kovacik@dgtfactory.com",
+    "TEL;TYPE=work:00421907813840",
+    "ORG:DGT factory, a. s.",
+    "TITLE:President of space",
+    "END:VCARD",
+    "",
+  ].join("\r\n");
+
+  const w = createWBXML("AirSync");
+  w.otag("ApplicationData");
+  appendApplicationDataFromVCard({
+    builder: w,
+    vCard: vcard,
+    asVersion: "16.1",
+    separator: ",",
+  });
+  w.switchpage("AirSync");
+  w.ctag();
+  const node = parseAdNode(decodeWBXML(w.getBytes()));
+
+  assert.equal(readPathFrom(node, ["FirstName"]), "Tomas");
+  assert.equal(readPathFrom(node, ["LastName"]), "Kovacik");
+  assert.equal(readPathFrom(node, ["Email1Address"]), "kovacik@dgtfactory.com");
+  assert.equal(readPathFrom(node, ["BusinessPhoneNumber"]), "00421907813840");
+  assert.equal(readPathFrom(node, ["CompanyName"]), "DGT factory, a. s.");
+  assert.equal(readPathFrom(node, ["JobTitle"]), "President of space");
+});

--- a/tests/unit/task-codec.test.mjs
+++ b/tests/unit/task-codec.test.mjs
@@ -1,0 +1,219 @@
+// task-codec.mjs: EAS Tasks (codepage 9) <-> iCal VTODO. Same shape as
+// calendar-codec.mjs's applicationDataToIcal/appendApplicationDataFromIcal
+// but for VTODO - not covered by any calendar-codec test, and not
+// touched at all until now.
+
+import { test, beforeAll } from "vitest";
+import assert from "node:assert/strict";
+import "../support/webext-shim.mjs";
+import ICAL from "../../src/vendor/ical.min.js";
+import {
+  applicationDataToIcal,
+  appendApplicationDataFromIcal,
+  readEasServerIdFromIcal,
+  stampEasServerId,
+} from "../../src/modules/eas/task-codec.mjs";
+import { createWBXML, decodeWBXML } from "../../src/modules/wbxml.mjs";
+import { ensureLoaded } from "../../src/modules/eas/timezone-mapping.mjs";
+import { parseAdNode } from "../support/xml-node.mjs";
+import { readPathFrom } from "../../src/modules/eas/wbxml-helpers.mjs";
+
+beforeAll(() => ensureLoaded());
+
+const ADD_TASK = `<ApplicationData>
+  <Subject xmlns='Tasks'>test-task</Subject>
+  <Body xmlns='AirSyncBase'><Type xmlns='AirSyncBase'>1</Type><Data xmlns='AirSyncBase'>a%20task%20body</Data></Body>
+  <Importance xmlns='Tasks'>2</Importance>
+  <Sensitivity xmlns='Tasks'>2</Sensitivity>
+  <UtcStartDate xmlns='Tasks'>2026-08-01T10:00:00.000Z</UtcStartDate>
+  <StartDate xmlns='Tasks'>2026-08-01T10:00:00.000Z</StartDate>
+  <UtcDueDate xmlns='Tasks'>2026-08-03T10:00:00.000Z</UtcDueDate>
+  <DueDate xmlns='Tasks'>2026-08-03T10:00:00.000Z</DueDate>
+  <Complete xmlns='Tasks'>0</Complete>
+  <ReminderSet xmlns='Tasks'>1</ReminderSet>
+  <ReminderTime xmlns='Tasks'>2026-08-01T09:00:00.000Z</ReminderTime>
+  <Categories xmlns='Tasks'>
+    <Category xmlns='Tasks'>Work</Category>
+  </Categories>
+</ApplicationData>`;
+
+function firstVtodo(icalString) {
+  return new ICAL.Component(ICAL.parse(icalString)).getFirstSubcomponent(
+    "vtodo",
+  );
+}
+
+test("applicationDataToIcal: maps Subject/Body/Importance/Sensitivity/Start/Due/Categories", () => {
+  const ical = applicationDataToIcal({
+    adNode: parseAdNode(ADD_TASK),
+    existingIcal: null,
+    serverID: "server-id-task-1",
+    asVersion: "16.1",
+    defaultTimezone: "UTC",
+    syncRecurrence: false,
+    msTodoCompat: false,
+    uid: null,
+  });
+
+  const vtodo = firstVtodo(ical);
+  assert.equal(vtodo.getFirstPropertyValue("summary"), "test-task");
+  assert.equal(vtodo.getFirstPropertyValue("description"), "a task body");
+  assert.equal(vtodo.getFirstPropertyValue("priority"), 1); // Importance 2 -> PRIORITY 1
+  assert.equal(vtodo.getFirstPropertyValue("class"), "PRIVATE"); // Sensitivity 2
+  assert.equal(
+    vtodo.getFirstPropertyValue("dtstart").toString(),
+    "2026-08-01T10:00:00Z",
+  );
+  assert.equal(
+    vtodo.getFirstPropertyValue("due").toString(),
+    "2026-08-03T10:00:00Z",
+  );
+  assert.deepEqual(vtodo.getFirstProperty("categories").getValues(), ["Work"]);
+  assert.equal(readEasServerIdFromIcal(ical), "server-id-task-1");
+});
+
+test("applicationDataToIcal: Complete=1 sets STATUS/PERCENT-COMPLETE/COMPLETED", () => {
+  const completedAd = ADD_TASK.replace(
+    "<Complete xmlns='Tasks'>0</Complete>",
+    "<Complete xmlns='Tasks'>1</Complete><DateCompleted xmlns='Tasks'>2026-08-02T10:00:00.000Z</DateCompleted>",
+  );
+  const ical = applicationDataToIcal({
+    adNode: parseAdNode(completedAd),
+    existingIcal: null,
+    serverID: "server-id-task-1",
+    asVersion: "16.1",
+    defaultTimezone: "UTC",
+    syncRecurrence: false,
+    msTodoCompat: false,
+    uid: null,
+  });
+  const vtodo = firstVtodo(ical);
+  assert.equal(vtodo.getFirstPropertyValue("status"), "COMPLETED");
+  assert.equal(vtodo.getFirstPropertyValue("percent-complete"), 100);
+  assert.equal(
+    vtodo.getFirstPropertyValue("completed").toString(),
+    "2026-08-02T10:00:00Z",
+  );
+});
+
+test("applicationDataToIcal: Complete is merge-aware - clears a prior COMPLETED state when a later delta says Complete=0", () => {
+  const commonArgs = {
+    serverID: "server-id-task-1",
+    asVersion: "16.1",
+    defaultTimezone: "UTC",
+    syncRecurrence: false,
+    msTodoCompat: false,
+    uid: null,
+  };
+  const completedAd = ADD_TASK.replace(
+    "<Complete xmlns='Tasks'>0</Complete>",
+    "<Complete xmlns='Tasks'>1</Complete><DateCompleted xmlns='Tasks'>2026-08-02T10:00:00.000Z</DateCompleted>",
+  );
+  const afterComplete = applicationDataToIcal({
+    adNode: parseAdNode(completedAd),
+    existingIcal: null,
+    ...commonArgs,
+  });
+
+  const reopened = applicationDataToIcal({
+    adNode: parseAdNode(
+      `<ApplicationData><Complete xmlns='Tasks'>0</Complete></ApplicationData>`,
+    ),
+    existingIcal: afterComplete,
+    ...commonArgs,
+  });
+  const vtodo = firstVtodo(reopened);
+  assert.equal(vtodo.getFirstPropertyValue("status"), null);
+  assert.equal(vtodo.getFirstPropertyValue("percent-complete"), null);
+  assert.equal(vtodo.getFirstPropertyValue("completed"), null);
+});
+
+test("applicationDataToIcal: a delta without <Complete> leaves an existing completion state untouched", () => {
+  const commonArgs = {
+    serverID: "server-id-task-1",
+    asVersion: "16.1",
+    defaultTimezone: "UTC",
+    syncRecurrence: false,
+    msTodoCompat: false,
+    uid: null,
+  };
+  const completedAd = ADD_TASK.replace(
+    "<Complete xmlns='Tasks'>0</Complete>",
+    "<Complete xmlns='Tasks'>1</Complete>",
+  );
+  const afterComplete = applicationDataToIcal({
+    adNode: parseAdNode(completedAd),
+    existingIcal: null,
+    ...commonArgs,
+  });
+
+  const afterSubjectEdit = applicationDataToIcal({
+    adNode: parseAdNode(
+      `<ApplicationData><Subject xmlns='Tasks'>renamed</Subject></ApplicationData>`,
+    ),
+    existingIcal: afterComplete,
+    ...commonArgs,
+  });
+  const vtodo = firstVtodo(afterSubjectEdit);
+  assert.equal(vtodo.getFirstPropertyValue("summary"), "renamed");
+  assert.equal(vtodo.getFirstPropertyValue("status"), "COMPLETED");
+});
+
+test("stampEasServerId / readEasServerIdFromIcal round-trip", () => {
+  const ical = applicationDataToIcal({
+    adNode: parseAdNode(ADD_TASK),
+    existingIcal: null,
+    serverID: "original-id",
+    asVersion: "16.1",
+    defaultTimezone: "UTC",
+    syncRecurrence: false,
+    msTodoCompat: false,
+    uid: null,
+  });
+  const restamped = stampEasServerId(ical, "new-id");
+  assert.equal(readEasServerIdFromIcal(restamped), "new-id");
+});
+
+test("appendApplicationDataFromIcal: outbound round-trip via the real WBXML encoder/decoder", () => {
+  const ical = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:0400-task-outbound-uid
+SUMMARY:test-task-outbound
+PRIORITY:1
+STATUS:COMPLETED
+PERCENT-COMPLETE:100
+DTSTART:20260801T100000Z
+DUE:20260803T100000Z
+COMPLETED:20260802T100000Z
+CATEGORIES:Work,Home
+END:VTODO
+END:VCALENDAR
+`;
+
+  const w = createWBXML("AirSync");
+  w.otag("ApplicationData");
+  appendApplicationDataFromIcal({
+    builder: w,
+    ical,
+    asVersion: "16.1",
+    defaultTimezone: "UTC",
+    syncRecurrence: false,
+  });
+  w.switchpage("AirSync");
+  w.ctag();
+  const node = parseAdNode(decodeWBXML(w.getBytes()));
+
+  assert.equal(readPathFrom(node, ["Subject"]), "test-task-outbound");
+  assert.equal(readPathFrom(node, ["Importance"]), "2"); // PRIORITY 1 -> Importance 2
+  assert.equal(readPathFrom(node, ["Complete"]), "1");
+  assert.equal(readPathFrom(node, ["UtcStartDate"]), "2026-08-01T10:00:00.000Z");
+  assert.equal(readPathFrom(node, ["UtcDueDate"]), "2026-08-03T10:00:00.000Z");
+  assert.deepEqual(
+    node.children
+      .find((c) => c.tagName === "Categories")
+      ?.children.filter((c) => c.tagName === "Category")
+      .map((c) => c.textContent),
+    ["Work", "Home"],
+  );
+});

--- a/tests/unit/timezone-blob.test.mjs
+++ b/tests/unit/timezone-blob.test.mjs
@@ -1,0 +1,92 @@
+// TimeZoneBlob (the 172-byte packed VTIMEZONE blob EAS <=14.x carries as
+// <Calendar:Timezone>) and isAllZero. No WebExtension host dependency
+// at all here - pure DataView/atob/btoa - so no shim needed.
+
+import { test } from "vitest";
+import assert from "node:assert/strict";
+import { TimeZoneBlob, isAllZero } from "../../src/modules/eas/timezone-blob.mjs";
+
+test("round-trip: every field written survives a set/get(easTimeZone64)/reload cycle", () => {
+  const tz = new TimeZoneBlob();
+  tz.utcOffset = -60;
+  tz.standardName = "Central Europe Standard Time";
+  tz.standardBias = 0;
+  tz.daylightName = "Central Europe Daylight Time";
+  tz.daylightBias = -60;
+  tz.standardDate.wMonth = 10;
+  tz.standardDate.wDayOfWeek = 0;
+  tz.standardDate.wDay = 5; // "last" occurrence
+  tz.standardDate.wHour = 3;
+  tz.daylightDate.wMonth = 3;
+  tz.daylightDate.wDayOfWeek = 0;
+  tz.daylightDate.wDay = 5;
+  tz.daylightDate.wHour = 2;
+
+  const reloaded = new TimeZoneBlob();
+  reloaded.easTimeZone64 = tz.easTimeZone64;
+
+  assert.equal(reloaded.utcOffset, -60);
+  assert.equal(reloaded.standardName, "Central Europe Standard Time");
+  assert.equal(reloaded.standardBias, 0);
+  assert.equal(reloaded.daylightName, "Central Europe Daylight Time");
+  assert.equal(reloaded.daylightBias, -60);
+  assert.equal(reloaded.standardDate.wMonth, 10);
+  assert.equal(reloaded.standardDate.wDay, 5);
+  assert.equal(reloaded.standardDate.wHour, 3);
+  assert.equal(reloaded.daylightDate.wMonth, 3);
+  assert.equal(reloaded.daylightDate.wHour, 2);
+});
+
+test("setting easTimeZone64 clears any previously-set bytes first (no stale leftovers)", () => {
+  const tz = new TimeZoneBlob();
+  tz.standardName = "Some Long Standard Name That Fills Space";
+  tz.utcOffset = 120;
+
+  tz.easTimeZone64 = null; // per the setter, falsy input zeroes the buffer
+  assert.equal(tz.utcOffset, 0);
+  assert.equal(tz.standardName, "");
+});
+
+test("a name is truncated to 32 UTF-16 code units, not overflowed into the next field", () => {
+  const tz = new TimeZoneBlob();
+  const tooLong = "x".repeat(40);
+  tz.standardName = tooLong;
+  assert.equal(tz.standardName, "x".repeat(32));
+  // daylightBias (next field after standardName+standardDate+standardBias)
+  // must not have been clobbered by the overflow.
+  assert.equal(tz.standardBias, 0);
+});
+
+test("real captured blob (kovacik@dgtfactory.com, live Exchange, Central Europe zone) decodes correctly", () => {
+  // Captured verbatim from a TbSync debug log, percent-encoded exactly as
+  // it appears in the wire <Calendar:Timezone> text content.
+  const wireText =
+    "xP%2F%2F%2F0MAZQBuAHQAcgBhAGwAIABFAHUAcgBvAHAAZQAgAFMAdABhAG4AZABhAHIAZAAgAFQAaQBtAGUAAAAAAAAAAAAAAAoAAAAFAAMAAAAAAAAAAAAAACgAVQBUAEMAKwAwADEAOgAwADAAKQAgAEIAZQBsAGcAcgBhAGQAZQAsACAAQgByAGEAdABpAHMAbABhAHYAYQAAAAMAAAAFAAIAAAAAAAAAxP%2F%2F%2Fw%3D%3D";
+  const tz = new TimeZoneBlob();
+  tz.easTimeZone64 = decodeURIComponent(wireText);
+
+  assert.equal(tz.utcOffset, -60);
+  assert.equal(tz.standardName, "Central Europe Standard Time");
+  assert.equal(tz.standardBias, 0);
+  assert.equal(tz.daylightName, "(UTC+01:00) Belgrade, Bratislava");
+  assert.equal(tz.daylightBias, -60);
+});
+
+test("isAllZero: true for null/undefined/empty", () => {
+  assert.equal(isAllZero(null), true);
+  assert.equal(isAllZero(undefined), true);
+  assert.equal(isAllZero(""), true);
+});
+
+test("isAllZero: true for a genuinely all-zero blob, false once any byte is set", () => {
+  const zero = new TimeZoneBlob();
+  assert.equal(isAllZero(zero.easTimeZone64), true);
+
+  const nonZero = new TimeZoneBlob();
+  nonZero.utcOffset = 1;
+  assert.equal(isAllZero(nonZero.easTimeZone64), false);
+});
+
+test("isAllZero: malformed base64 is treated as all-zero (safe fallback), not a throw", () => {
+  assert.equal(isAllZero("not valid base64 !!!"), true);
+});

--- a/tests/unit/wbxml-helpers.test.mjs
+++ b/tests/unit/wbxml-helpers.test.mjs
@@ -1,0 +1,85 @@
+// wbxml-helpers.mjs directly: readPath/readPathFrom/readChildTexts, and
+// specifically the percent-encoding + UTF-8 reinterpret round-trip the
+// module's own docblock warns about ("ü" (UTF-8 0xC3 0xBC) surfacing as
+// "Ã¼" without the second decode step) - exercised through the REAL
+// WBXML encoder/decoder (wbxml.mjs), not a hand-crafted percent-encoded
+// fixture, so this is a faithful end-to-end check of the actual wire
+// round-trip, not just the helper's own logic in isolation.
+
+import { test } from "vitest";
+import assert from "node:assert/strict";
+import {
+  readPath,
+  readPathFrom,
+  readChildTexts,
+} from "../../src/modules/eas/wbxml-helpers.mjs";
+import { createWBXML, decodeWBXML } from "../../src/modules/wbxml.mjs";
+import { parseAdNode } from "../support/xml-node.mjs";
+
+function docFromXml(xml) {
+  return { documentElement: parseAdNode(xml) };
+}
+
+test("readPath: walks a multi-level path and returns the leaf's decoded text", () => {
+  const doc = docFromXml(
+    `<Root><A><B>hello</B></A></Root>`,
+  );
+  assert.equal(readPath(doc, ["A", "B"]), "hello");
+});
+
+test("readPath: a missing intermediate step returns null, not a throw", () => {
+  const doc = docFromXml(`<Root><A/></Root>`);
+  assert.equal(readPath(doc, ["A", "B", "C"]), null);
+});
+
+test("readPath: no documentElement at all returns null", () => {
+  assert.equal(readPath({ documentElement: null }, ["A"]), null);
+  assert.equal(readPath(null, ["A"]), null);
+});
+
+test("readPath: an empty path array returns the root's own text", () => {
+  const doc = docFromXml(`<Root>direct-text</Root>`);
+  assert.equal(readPath(doc, []), "direct-text");
+});
+
+test("readPathFrom: starts at a given node instead of the document root", () => {
+  const doc = docFromXml(`<Root><Item><Name>widget</Name></Item></Root>`);
+  const item = doc.documentElement.children.find((c) => c.tagName === "Item");
+  assert.equal(readPathFrom(item, ["Name"]), "widget");
+});
+
+test("readPathFrom: a null starting node returns null immediately", () => {
+  assert.equal(readPathFrom(null, ["Name"]), null);
+});
+
+test("readChildTexts: collects every direct child matching the tag, in order", () => {
+  const doc = docFromXml(
+    `<Categories><Category>Work</Category><Category>Personal</Category></Categories>`,
+  );
+  assert.deepEqual(readChildTexts(doc.documentElement, "Category"), [
+    "Work",
+    "Personal",
+  ]);
+});
+
+test("readChildTexts: skips empty/whitespace-only entries and non-matching siblings", () => {
+  const doc = docFromXml(
+    `<Categories><Category>Work</Category><Category></Category><Other>ignored</Other></Categories>`,
+  );
+  assert.deepEqual(readChildTexts(doc.documentElement, "Category"), ["Work"]);
+});
+
+test("readChildTexts: no children at all returns an empty array, not a throw", () => {
+  assert.deepEqual(readChildTexts({ children: undefined }, "Category"), []);
+});
+
+test("percent-encoding + UTF-8 reinterpret round-trip: accented text survives the real WBXML wire format", () => {
+  const original = "Tomáš Kováčik — café";
+  const w = createWBXML("AirSync");
+  w.otag("Add");
+  w.atag("ServerId", original);
+  w.ctag();
+  const xml = decodeWBXML(w.getBytes());
+  const doc = docFromXml(xml);
+  assert.equal(readPath(doc, ["ServerId"]), original);
+});


### PR DESCRIPTION
## Summary

Adds an automated test suite for the pure-logic parts of the add-on:
EAS `<ApplicationData>` <-> iCal/vCard conversion, the WBXML helper
functions, and `sync-runner.mjs`'s push orchestration. No new runtime
dependency - `vitest` is a dev-only dependency, everything under test
is exercised through the real WBXML encoder/decoder, not stubs.

Two tests double as regression evidence for issues already filed
against this repo:

- `sync-runner.bundled-instance-change.test.mjs` demonstrates that a
  modified recurring item's master `<Change>` and its per-occurrence
  `InstanceId` `<Change>` get sent under the same `ServerId` in one
  `<Sync>` request (#334), and documents today's retry/changelog
  behavior when a server rejects both.
- `calendar-codec.inbound-exceptions.test.mjs` documents that a second,
  status-only touch of an already-synced recurrence exception drops its
  Subject/Start/End locally (#342), because the exception is rebuilt
  from an empty component on every update with no inheritance from the
  prior state.

Both are written as characterization tests - they assert today's actual
behavior on purpose, so a fix has to touch the test file rather than
land unverified.

`appendCommands` and `applyResponses` in `sync-runner.mjs` are exported
test-only (every production caller still reaches them through the
normal `pushPhase`/`runOneSync` flow) so their request/response
handling can be driven directly without mocking the network.

Full rationale, tooling choices, and known gaps (the WebExtension host
boundary - `messenger.calendar.timezones.*` isn't available outside
Thunderbird, shimmed for the common UTC-only path) are in `TESTING.md`.

## Test plan

- [x] `npm test` (vitest run) - 49 tests across 11 files, all passing
- [x] Verified on Node 20.x and Node 22.x, both locally and via
      `Dockerfile.test`
- [x] CI added (`.github/workflows/test.yml`), Node 20.x/22.x matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)