### PR TITLE
Say how the live suite is actually started

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -81,18 +81,31 @@ and the version model against fixtures. Fast enough to run on every edit.
 ## The live suite
 
 ```
-npm test                    every test that applies to the granted account
-npm test -- 7               one section
-npm test -- 7.3             one step
-npm test -- 2 5             several
+npm test                    whether a run is going, and how to start one
+npm test -- --run           every test that applies to the granted account
+npm test -- --run 7         one section
+npm test -- --run 7.3       one step
+npm test -- --run 2 5       several
 npm test -- --list          what would run, and what gates each  (instant)
-npm test -- --watch <log>   attach to a run: last 20 lines, then follow
-npm test -- --no-watch      start it and return, without attaching
+npm test -- --watch         follow the run that is going
+npm test -- --watch <log>   read an older run back: last 20 lines, then follow
+npm test -- --no-watch      with --run: start it and return, without attaching
+npm test -- --stop          stop the run, unwinding so the account goes back
 ```
 
 This one drives a real account against a real server. It is the only thing
 that can tell you what a server actually stored, and it is slow - a full
 run is roughly an hour, most of it deliberate pacing.
+
+**The bare command starts nothing.** It reports, and says how to start a
+run. A run takes tens of minutes and reconfigures a live account, which is
+more than the most reflexive command in the repo should do by reflex, so
+starting is asked for by name - `--run`, beside `--list`.
+
+**One run at a time**, because every run owns the same account: it changes
+settings, disconnects resources and puts them back. Two at once interleave
+that, and what comes out is not a result about the code. A second start is
+refused and says which run holds the account.
 
 ### What it needs
 
@@ -126,18 +139,21 @@ A run is started in the background and writes its report as it goes:
   started in the background
   log    /path/to/test/runs/20260830-095945-all.log
   pid    1550474
-  watch  tail -f /path/to/test/runs/20260830-095945-all.log
-  stop   kill 1550474   (cleans up; kill -9 does not)
+  watch  npm test -- --watch
+  stop   npm test -- --stop   (unwinds; kill -9 does not)
 ```
 
-`npm test` then attaches to that log. **Ctrl-C stops the watching, not the
-run** - the run is in its own session and never sees the signal. Come back
-to it with `npm test -- --watch <log>`, which prints the last 20 lines
-before following, so attaching an hour in tells you where it has got to.
+`--run` then attaches to that log, unless you passed `--no-watch`.
+**Ctrl-C stops the watching, not the run** - the run is in its own session
+and never sees the signal. Come back to it with `npm test -- --watch`,
+which prints the last 20 lines before following, so attaching an hour in
+tells you where it has got to; name a log to read an older run back.
 
-`kill <pid>` is the clean stop: the run unwinds, puts the account's
-settings back, and says so in the log. `kill -9` cannot be caught, so it
-skips all of that and leaves the account as the run had it.
+`npm test -- --stop` is the clean stop: the run unwinds, puts the account's
+settings back, and says so in the log. `kill <pid>` does the same - the run
+catches the signal in order to unwind - but has you find the id first.
+`kill -9` cannot be caught, so it skips all of that and leaves the account
+as the run had it.
 
 Each run also writes an event-log capture to `test/wire/` - the wire for a
 failing run is usually the only thing that says what really happened.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -88,7 +88,7 @@ npm test -- --run 7.3       one step
 npm test -- --run 2 5       several
 npm test -- --list          what would run, and what gates each  (instant)
 npm test -- --watch         follow the run that is going
-npm test -- --watch <log>   read an older run back: last 20 lines, then follow
+npm test -- --watch <log>   read an older run back from the top, then follow
 npm test -- --no-watch      with --run: start it and return, without attaching
 npm test -- --stop          stop the run, unwinding so the account goes back
 ```
@@ -146,8 +146,8 @@ A run is started in the background and writes its report as it goes:
 `--run` then attaches to that log, unless you passed `--no-watch`.
 **Ctrl-C stops the watching, not the run** - the run is in its own session
 and never sees the signal. Come back to it with `npm test -- --watch`,
-which prints the last 20 lines before following, so attaching an hour in
-tells you where it has got to; name a log to read an older run back.
+which prints the log from the start before following, so attaching an hour
+in shows the whole run so far; name a log to read an older run back.
 
 `npm test -- --stop` is the clean stop: the run unwinds, puts the account's
 settings back, and says so in the log. `kill <pid>` does the same - the run


### PR DESCRIPTION
`DEVELOPMENT.md` still documented `npm test` as the command that runs the live
suite. It isn't, and hasn't been since fc8257a3 ("One test run at a time, and
let npm test say so") made starting a run ask for `--run` by name. Every start
command the file listed therefore started nothing — the bare command prints a
status report and exits — so the suite reads as broken to anyone following the
docs. The gate is `test/run.py:445`: no `--run` in the arguments, and it reports
instead of running.

## What changed

The command listing now matches `run.py`:

| the file said | what it does | now documented as |
| --- | --- | --- |
| `npm test` | reports whether a run is going | `npm test -- --run` |
| `npm test -- 7` | nothing | `npm test -- --run 7` |
| `npm test -- 7.3` | nothing | `npm test -- --run 7.3` |
| `npm test -- 2 5` | nothing | `npm test -- --run 2 5` |
| `npm test -- --no-watch` | nothing on its own | `npm test -- --run --no-watch` |
| `npm test -- --watch <log>` | works; the path is optional | both forms, since bare `--watch` follows the run that is going and a path reads an older run back |

`--list` was correct and is unchanged. `--stop` was never mentioned at all and
is now in the listing.

Two paragraphs explain what the flag is for, because a listing alone doesn't
say why the most reflexive command in the repo declines to do anything: the
bare command starts nothing on purpose, and only one run may go at a time
since every run takes over and restores the same account's settings.

## Watching, and stopping

Stale in the same way, in three places:

- the quoted launcher output named `tail -f <log>` and `kill 1550474`; it now
  prints `npm test -- --watch` and `npm test -- --stop`
- the text had the bare command attaching to a log it no longer starts — that
  is `--run`, unless `--no-watch` was passed
- `kill <pid>` was given as the clean stop. Still true, and still said: the run
  catches SIGTERM in order to unwind. `npm test -- --stop` is now named first,
  as it doesn't have you find the process id.

Documentation only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)