### PR TITLE
Fix/keep hidden calendars hidden

### DIFF
--- a/src/experiments/calendar/CHANGES.txt
+++ b/src/experiments/calendar/CHANGES.txt
@@ -52,7 +52,8 @@ Items 0-4 are in child/ext-calendar-timezones.js, item 5 in
 parent/ext-calendar-timezones.js, item 6 in schema/calendar-calendars.json,
 ext-calendar-utils.sys.mjs and parent/ext-calendar-calendars.js, items 7 and
 8 in parent/ext-calendar-provider.js, item 9 in ext-calendar-utils.sys.mjs,
-parent/ext-calendar-provider.js and parent/ext-calendar-items.js.
+parent/ext-calendar-provider.js and parent/ext-calendar-items.js, item 10
+in parent/ext-calendar-provider.js.
 
 0. Priming the timezone service. This runs in the child process, where the
    service is a fresh instance Thunderbird's own startup never touched -
@@ -286,6 +287,60 @@ parent/ext-calendar-provider.js and parent/ext-calendar-items.js.
 
    Upstream's own gap rather than a deviation we want, like item 8, and
    worth offering there.
+
+10. A hidden calendar stays hidden across a restart. Registering and
+   unregistering the provider type each carry calendar-main-in-composite
+   over the swap they cause; without that, every calendar this add-on
+   supplies comes back visible on every start, reload, update and disable.
+
+   Hidden is the *absence* of that property, not a false: hiding a calendar
+   calls CalCompositeCalendar.removeCalendar, which deleteProperty's it.
+   Registering the type calls updateCalendarRegistration, which replaces
+   each force-disabled placeholder with a real calendar - and along the way
+   the composite deletes the property for every one of them (its guard,
+   `newCalendars.length != this.mCalendars`, compares a number with an
+   array and so is always true), then cal.view's manager observer runs
+
+       const inComposite = calendar.getProperty(prefix + "-in-composite");
+       if (inComposite === null && !calendar.getProperty("disabled")) {
+         comp.addCalendar(calendar);
+       }
+
+   and reads the absence it was just handed as a calendar nobody has an
+   opinion about yet. auto-enabled has cleared `disabled` by then, so this
+   fires for all of them and writes the property back as true. The user's
+   answer and a manufactured one are the same value by the time anything
+   looks, which is why the snapshot has to be taken before
+   registerCalendarProvider and applied after it.
+
+   The restore goes through the composite, not through the property: the
+   calendar is in the composite by then, so writing the property alone
+   would uncheck the box in the calendar list and leave the calendar's
+   events on the view until the next restart. unregister() is the mirror
+   image and needs the property written directly instead - the placeholder
+   is force-disabled and nothing put it in a composite, so adding it would
+   put a calendar that cannot answer anything onto the view. Without that
+   half, register() would find every calendar looking hidden and hide the
+   lot on the next reload.
+
+   Nothing in this add-on or in TbSync ever wrote `visible`, and the
+   property is a complete store on its own - all it needed was to survive
+   re-registration. Thunderbird's own re-registration path already knows
+   this: changeCalendarCache copies calendar-main-in-composite in its
+   propsToCopy list, while updateCalendarRegistration preserves only
+   initialSortOrderPos.
+
+   Measured on Thunderbird 153.2.0esr with an Exchange account: before, all
+   ten calendar.registry.<id>.calendar-main-in-composite prefs of type
+   ext-eas4tbsync@jobisoft.de read true however many were hidden, while
+   hidden gdata and caldav calendars in the same profile had no such pref
+   and stayed hidden.
+
+   Reported as TbSync#817. This hits every WebExtension calendar provider,
+   not just this one - registration is always deferred to
+   background-script-started, so the composite always exists by then - so
+   it is upstream's bug as much as item 8 and item 9, and worth offering
+   both there and to Thunderbird.
 
 Verified against Thunderbird 153.0.2 (esr153), 154.0 (beta) and 155.0a1:
 every other member these files touch - defaultTimezone, timezoneIds and

--- a/src/experiments/calendar/CHANGES.txt
+++ b/src/experiments/calendar/CHANGES.txt
@@ -334,6 +334,12 @@ in parent/ext-calendar-provider.js.
    not just this one, so it is upstream's bug as much as item 8 and item 9
    and is worth offering both there and to Thunderbird.
 
+   The one item TbSync's copy does not carry, so `diff -r` between the two
+   copies reports this file and parent/ext-calendar-provider.js. TbSync
+   declares the calendar_provider experiment API but not the manifest key
+   that registers a calendar type, so neither register() nor unregister()
+   ever runs there and the change would sit inert.
+
 Verified against Thunderbird 153.0.2 (esr153), 154.0 (beta) and 155.0a1:
 every other member these files touch - defaultTimezone, timezoneIds and
 calITimezoneDatabase.getTimezoneDefinition - is present unchanged in all

--- a/src/experiments/calendar/CHANGES.txt
+++ b/src/experiments/calendar/CHANGES.txt
@@ -288,40 +288,33 @@ in parent/ext-calendar-provider.js.
    Upstream's own gap rather than a deviation we want, like item 8, and
    worth offering there.
 
-10. A hidden calendar stays hidden across a restart. Registering and
-   unregistering the provider type each carry calendar-main-in-composite
-   over the swap they cause; without that, every calendar this add-on
-   supplies comes back visible on every start, reload, update and disable.
+10. A hidden calendar stays hidden across a restart. Without this, every
+   calendar this add-on supplies comes back visible on every start, reload,
+   update and disable, however many times the user hides it.
 
-   Hidden is the *absence* of that property, not a false: hiding a calendar
-   calls CalCompositeCalendar.removeCalendar, which deleteProperty's it.
-   Registering the type calls updateCalendarRegistration, which replaces
-   each force-disabled placeholder with a real calendar - and along the way
-   the composite deletes the property for every one of them (its guard,
-   `newCalendars.length != this.mCalendars`, compares a number with an
-   array and so is always true), then cal.view's manager observer runs
+   A hidden calendar has no calendar-main-in-composite property: hiding one
+   calls CalCompositeCalendar.removeCalendar, which deletes it rather than
+   writing false. Registering our calendar type then deletes the property
+   for all of our calendars in passing, because it replaces each
+   force-disabled placeholder with a real calendar and the composite is
+   handed each placeholder to remove on the way. cal.view's manager observer
+   sees a calendar with no such property, takes it for one it has never seen
+   and shows it - so the user's answer and a freshly deleted property are
+   the same thing by the time anything looks.
 
-       const inComposite = calendar.getProperty(prefix + "-in-composite");
-       if (inComposite === null && !calendar.getProperty("disabled")) {
-         comp.addCalendar(calendar);
-       }
+   Rather than put the property back afterwards, ExtCalendar.getProperty
+   reports false for the calendars that were hidden when the type was
+   registered, for as long as the stored property stays missing. Nothing
+   then ever reads the missing property that would be mistaken for a new
+   calendar, and false and missing mean the same to every reader. A first
+   attempt did correct the state afterwards, by removing the calendar from
+   each window's composite once registration was over; that did not work,
+   and it needed to find the composites, which this does not.
 
-   and reads the absence it was just handed as a calendar nobody has an
-   opinion about yet. auto-enabled has cleared `disabled` by then, so this
-   fires for all of them and writes the property back as true. The user's
-   answer and a manufactured one are the same value by the time anything
-   looks, which is why the snapshot has to be taken before
-   registerCalendarProvider and applied after it.
-
-   The restore goes through the composite, not through the property: the
-   calendar is in the composite by then, so writing the property alone
-   would uncheck the box in the calendar list and leave the calendar's
-   events on the view until the next restart. unregister() is the mirror
-   image and needs the property written directly instead - the placeholder
-   is force-disabled and nothing put it in a composite, so adding it would
-   put a calendar that cannot answer anything onto the view. Without that
-   half, register() would find every calendar looking hidden and hide the
-   lot on the next reload.
+   unregister() is the other half. It deletes the property as well, so the
+   ids that were visible are written back after the swap - otherwise the
+   next register() would find every calendar looking hidden and hide the
+   lot.
 
    Nothing in this add-on or in TbSync ever wrote `visible`, and the
    property is a complete store on its own - all it needed was to survive
@@ -330,17 +323,16 @@ in parent/ext-calendar-provider.js.
    propsToCopy list, while updateCalendarRegistration preserves only
    initialSortOrderPos.
 
-   Measured on Thunderbird 153.2.0esr with an Exchange account: before, all
-   ten calendar.registry.<id>.calendar-main-in-composite prefs of type
+   Measured on Thunderbird 153.2.0esr with an Exchange account: before,
+   every calendar.registry.<id>.calendar-main-in-composite pref of type
    ext-eas4tbsync@jobisoft.de read true however many were hidden, while
    hidden gdata and caldav calendars in the same profile had no such pref
-   and stayed hidden.
+   and stayed hidden. After, hiding four of them and restarting left those
+   four without the pref and the other five reading true.
 
    Reported as TbSync#817. This hits every WebExtension calendar provider,
-   not just this one - registration is always deferred to
-   background-script-started, so the composite always exists by then - so
-   it is upstream's bug as much as item 8 and item 9, and worth offering
-   both there and to Thunderbird.
+   not just this one, so it is upstream's bug as much as item 8 and item 9
+   and is worth offering both there and to Thunderbird.
 
 Verified against Thunderbird 153.0.2 (esr153), 154.0 (beta) and 155.0a1:
 every other member these files touch - defaultTimezone, timezoneIds and

--- a/src/experiments/calendar/parent/ext-calendar-provider.js
+++ b/src/experiments/calendar/parent/ext-calendar-provider.js
@@ -97,6 +97,49 @@ function liveComposites() {
   return composites;
 }
 
+// The calendars of ours the user had hidden when the type was registered.
+//
+// This is what makes the answer to "is it hidden" survive registration
+// without depending on finding anything: while an id is in here and the
+// stored property is still absent, ExtCalendar.getProperty answers false
+// rather than null, and the observer that would otherwise take the absence
+// for a brand new calendar and show it leaves the calendar alone. Every
+// reader treats false and the absence identically, so nothing else changes.
+const hiddenAtRegistration = new Set();
+
+// How many times that answer was actually given, for the debug pref below.
+let visibilityGuardHits = 0;
+
+// The stored property, read straight out of the pref rather than through the
+// calendar, so it reports the absence the calendar is hiding.
+function storedInComposite(id) {
+  const name = `calendar.registry.${id}.calendar-main-in-composite`;
+  if (Services.prefs.getPrefType(name) == Ci.nsIPrefBranch.PREF_INVALID) {
+    return "absent";
+  }
+  return String(Services.prefs.getBoolPref(name, false));
+}
+
+// TEMPORARY, for TbSync#817: leave behind what the carry-over saw, so a
+// failure can be read out of prefs.js after a restart instead of guessed at.
+// Delete this and its two call sites once the fix is confirmed.
+function recordVisibilityDebug(type, hidden, composites) {
+  try {
+    const after = calendarsOfType(type)
+      .map(calendar => `${calendar.id.slice(0, 4)}:${storedInComposite(calendar.id)}`)
+      .join(" ");
+    Services.prefs.setStringPref(
+      "extensions.eas4tbsync.debug.calendarVisibility",
+      `at=${new Date().toTimeString().slice(0, 8)} ours=${calendarsOfType(type).length} ` +
+        `hidden=[${[...hidden].map(id => id.slice(0, 4)).join(" ")}] ` +
+        `composites=${composites} guardHits=${visibilityGuardHits} after=[${after}]`
+    );
+    Services.prefs.savePrefFile(null);
+  } catch (e) {
+    console.error("[ext-calendar] could not record visibility debug", e);
+  }
+}
+
 class ExtCalendarProvider {
   QueryInterface = ChromeUtils.generateQI(["calICalendarProvider"]);
 
@@ -118,9 +161,19 @@ class ExtCalendarProvider {
     // Registration is deferred to background-script-started, so this always
     // runs long after the main window built its composite - there is no
     // startup order in which the swap goes unobserved.
+    //
+    // Answering the swap is what hiddenAtRegistration does, and it needs
+    // nothing else to be true: the calendar itself reports false for as long
+    // as the absence lasts, so no observer ever sees a null to act on. The
+    // sweep below is the second line, for a reader that got there first.
+    hiddenAtRegistration.clear();
+    visibilityGuardHits = 0;
     const hidden = calendarsOfType(type)
       .filter(calendar => !calendar.getProperty("calendar-main-in-composite"))
       .map(calendar => calendar.id);
+    for (const id of hidden) {
+      hiddenAtRegistration.add(id);
+    }
 
     cal.manager.registerCalendarProvider(
       type,
@@ -131,20 +184,26 @@ class ExtCalendarProvider {
       }
     );
 
-    // Through the composite rather than by deleting the property again: the
-    // calendar is in the composite by now, and a property nobody acted on
-    // would uncheck the box in the calendar list while the calendar's events
-    // stayed on the view until the next restart. removeCalendar deletes the
-    // property itself, which is what hidden is.
+    // Through the composite rather than by deleting the property again: if
+    // anything did add the calendar, the property alone would uncheck the box
+    // in the calendar list while the calendar's events stayed on the view
+    // until the next restart. removeCalendar deletes the property itself,
+    // which is what hidden is. A no-op when the guard above did its job.
+    let composites = 0;
     for (const id of hidden) {
       const calendar = cal.manager.getCalendarById(id);
       if (!calendar) {
         continue;
       }
       for (const composite of liveComposites()) {
-        composite.removeCalendar(calendar);
+        composites++;
+        if (composite.getCalendarById(id)) {
+          composite.removeCalendar(calendar);
+        }
       }
     }
+
+    recordVisibilityDebug(type, hidden, composites);
 
     const provider = new ExtCalendarProvider(extension);
     cal.provider.register(provider);
@@ -293,6 +352,35 @@ class ExtCalendar extends cal.provider.BaseClass {
       case "cache.enabled":
       case "cache.always":
         return true;
+
+      case "calendar-main-in-composite": {
+        // False rather than null, for a calendar the user had hidden when
+        // the type was registered and that nothing has shown since.
+        //
+        // Hidden is the absence of this property, and registering the type
+        // deletes it for every calendar of the type on the way past. Whoever
+        // reads it next - cal.view's manager observer, on the registration
+        // this add-on just caused - takes that absence for a calendar nobody
+        // has an opinion about yet and shows it, which is how a hidden
+        // calendar came back on every start. False is an opinion, and every
+        // reader treats it exactly as it treats the absence, so answering it
+        // here settles the question before anyone can get it wrong.
+        //
+        // The answer lasts exactly as long as the absence. The moment
+        // anything writes the property - the user ticking the box in the
+        // calendar list, which goes through the composite and writes true -
+        // this stops answering and the stored value speaks for itself.
+        if (!hiddenAtRegistration.has(this.id)) {
+          break;
+        }
+        const stored = super.getProperty(name);
+        if (stored !== null) {
+          hiddenAtRegistration.delete(this.id);
+          return stored;
+        }
+        visibilityGuardHits++;
+        return false;
+      }
 
       case "organizerId":
         if (this.capabilities.organizer) {

--- a/src/experiments/calendar/parent/ext-calendar-provider.js
+++ b/src/experiments/calendar/parent/ext-calendar-provider.js
@@ -76,69 +76,17 @@ function stackContains(part) {
 }
 
 
-// The calendars of one provider type, as the calendar manager currently
-// holds them. That includes the force-disabled placeholders standing in for
-// them while the type is unregistered - which is exactly when this is asked.
+// Our own calendars, including the force-disabled placeholders that stand in
+// for them while our calendar type is not registered.
 function calendarsOfType(type) {
   return cal.manager.getCalendars().filter(calendar => calendar.type == type);
 }
 
-// The composite calendars that already exist. cal.view.getCompositeCalendar
-// builds one for a window that has none and installs its manager observer,
-// which is the last thing wanted here, so only windows already holding one
-// are considered. A window with no composite has no opinion to correct.
-function liveComposites() {
-  const composites = [];
-  for (const win of Services.wm.getEnumerator(null)) {
-    if (win._compositeCalendar) {
-      composites.push(win._compositeCalendar);
-    }
-  }
-  return composites;
-}
-
-// The calendars of ours the user had hidden when the type was registered.
-//
-// This is what makes the answer to "is it hidden" survive registration
-// without depending on finding anything: while an id is in here and the
-// stored property is still absent, ExtCalendar.getProperty answers false
-// rather than null, and the observer that would otherwise take the absence
-// for a brand new calendar and show it leaves the calendar alone. Every
-// reader treats false and the absence identically, so nothing else changes.
+// Calendars of ours the user had hidden when our type was registered. Both
+// hiding a calendar and registering the type delete the property that says
+// so, so without this record the two cannot be told apart afterwards. Read
+// by ExtCalendar.getProperty; see item 10 in CHANGES.txt.
 const hiddenAtRegistration = new Set();
-
-// How many times that answer was actually given, for the debug pref below.
-let visibilityGuardHits = 0;
-
-// The stored property, read straight out of the pref rather than through the
-// calendar, so it reports the absence the calendar is hiding.
-function storedInComposite(id) {
-  const name = `calendar.registry.${id}.calendar-main-in-composite`;
-  if (Services.prefs.getPrefType(name) == Ci.nsIPrefBranch.PREF_INVALID) {
-    return "absent";
-  }
-  return String(Services.prefs.getBoolPref(name, false));
-}
-
-// TEMPORARY, for TbSync#817: leave behind what the carry-over saw, so a
-// failure can be read out of prefs.js after a restart instead of guessed at.
-// Delete this and its two call sites once the fix is confirmed.
-function recordVisibilityDebug(type, hidden, composites) {
-  try {
-    const after = calendarsOfType(type)
-      .map(calendar => `${calendar.id.slice(0, 4)}:${storedInComposite(calendar.id)}`)
-      .join(" ");
-    Services.prefs.setStringPref(
-      "extensions.eas4tbsync.debug.calendarVisibility",
-      `at=${new Date().toTimeString().slice(0, 8)} ours=${calendarsOfType(type).length} ` +
-        `hidden=[${[...hidden].map(id => id.slice(0, 4)).join(" ")}] ` +
-        `composites=${composites} guardHits=${visibilityGuardHits} after=[${after}]`
-    );
-    Services.prefs.savePrefFile(null);
-  } catch (e) {
-    console.error("[ext-calendar] could not record visibility debug", e);
-  }
-}
 
 class ExtCalendarProvider {
   QueryInterface = ChromeUtils.generateQI(["calICalendarProvider"]);
@@ -146,33 +94,13 @@ class ExtCalendarProvider {
   static register(extension) {
     const type = "ext-" + extension.id;
 
-    // Which of ours the user had hidden, asked before anything moves.
-    //
-    // Hiding a calendar *deletes* its calendar-main-in-composite property -
-    // hidden is the absence of the property, not a false. Registering the
-    // type below replaces every placeholder with a real calendar, and that
-    // swap puts the property through two hands: the composite deletes it
-    // when the placeholder unregisters, and cal.view's manager observer
-    // then reads the absence as "a calendar nobody has an opinion about
-    // yet" and shows it. By then an absence the user asked for and one
-    // manufactured a moment ago look identical, so the answer has to be
-    // taken now and put back afterwards.
-    //
-    // Registration is deferred to background-script-started, so this always
-    // runs long after the main window built its composite - there is no
-    // startup order in which the swap goes unobserved.
-    //
-    // Answering the swap is what hiddenAtRegistration does, and it needs
-    // nothing else to be true: the calendar itself reports false for as long
-    // as the absence lasts, so no observer ever sees a null to act on. The
-    // sweep below is the second line, for a reader that got there first.
+    // Note what is hidden before registering, because registering deletes
+    // the property that records it.
     hiddenAtRegistration.clear();
-    visibilityGuardHits = 0;
-    const hidden = calendarsOfType(type)
-      .filter(calendar => !calendar.getProperty("calendar-main-in-composite"))
-      .map(calendar => calendar.id);
-    for (const id of hidden) {
-      hiddenAtRegistration.add(id);
+    for (const calendar of calendarsOfType(type)) {
+      if (!calendar.getProperty("calendar-main-in-composite")) {
+        hiddenAtRegistration.add(calendar.id);
+      }
     }
 
     cal.manager.registerCalendarProvider(
@@ -184,27 +112,6 @@ class ExtCalendarProvider {
       }
     );
 
-    // Through the composite rather than by deleting the property again: if
-    // anything did add the calendar, the property alone would uncheck the box
-    // in the calendar list while the calendar's events stayed on the view
-    // until the next restart. removeCalendar deletes the property itself,
-    // which is what hidden is. A no-op when the guard above did its job.
-    let composites = 0;
-    for (const id of hidden) {
-      const calendar = cal.manager.getCalendarById(id);
-      if (!calendar) {
-        continue;
-      }
-      for (const composite of liveComposites()) {
-        composites++;
-        if (composite.getCalendarById(id)) {
-          composite.removeCalendar(calendar);
-        }
-      }
-    }
-
-    recordVisibilityDebug(type, hidden, composites);
-
     const provider = new ExtCalendarProvider(extension);
     cal.provider.register(provider);
   }
@@ -212,10 +119,9 @@ class ExtCalendarProvider {
   static unregister(extension) {
     const type = "ext-" + extension.id;
 
-    // The same property, lost the other way round: unregistering hands each
-    // calendar to the composite to be removed, and that deletes it. Left
-    // alone, every calendar would look hidden to the register() above, so a
-    // reload, an update or a disable would hide the lot.
+    // Unregistering deletes the property too, so note which calendars were
+    // visible and write it back below. Otherwise the register() above would
+    // take them all for hidden ones and hide them on the next reload.
     const visible = calendarsOfType(type)
       .filter(calendar => calendar.getProperty("calendar-main-in-composite"))
       .map(calendar => calendar.id);
@@ -223,10 +129,6 @@ class ExtCalendarProvider {
     cal.manager.unregisterCalendarProvider(type, true);
     cal.provider.unregister(type);
 
-    // Writing the property is enough here, and going through the composite
-    // would be wrong: the placeholder that replaced the calendar is
-    // force-disabled, nothing added it to a composite, and adding it would
-    // put a calendar that cannot answer anything onto the view.
     for (const id of visible) {
       cal.manager.getCalendarById(id)?.setProperty("calendar-main-in-composite", true);
     }
@@ -353,23 +255,15 @@ class ExtCalendar extends cal.provider.BaseClass {
       case "cache.always":
         return true;
 
+      // A hidden calendar has no calendar-main-in-composite property, and
+      // registering our type deletes it for all of our calendars anyway.
+      // Thunderbird then treats a missing property as a calendar it has
+      // never seen and shows it, which is why a hidden calendar used to come
+      // back on every start. Reporting false instead keeps it hidden:
+      // readers treat false and missing alike, but only missing means "new".
+      // As soon as anything writes the property - ticking the box in the
+      // calendar list writes true - the stored value answers again.
       case "calendar-main-in-composite": {
-        // False rather than null, for a calendar the user had hidden when
-        // the type was registered and that nothing has shown since.
-        //
-        // Hidden is the absence of this property, and registering the type
-        // deletes it for every calendar of the type on the way past. Whoever
-        // reads it next - cal.view's manager observer, on the registration
-        // this add-on just caused - takes that absence for a calendar nobody
-        // has an opinion about yet and shows it, which is how a hidden
-        // calendar came back on every start. False is an opinion, and every
-        // reader treats it exactly as it treats the absence, so answering it
-        // here settles the question before anyone can get it wrong.
-        //
-        // The answer lasts exactly as long as the absence. The moment
-        // anything writes the property - the user ticking the box in the
-        // calendar list, which goes through the composite and writes true -
-        // this stops answering and the stored value speaks for itself.
         if (!hiddenAtRegistration.has(this.id)) {
           break;
         }
@@ -378,7 +272,6 @@ class ExtCalendar extends cal.provider.BaseClass {
           hiddenAtRegistration.delete(this.id);
           return stored;
         }
-        visibilityGuardHits++;
         return false;
       }
 

--- a/src/experiments/calendar/parent/ext-calendar-provider.js
+++ b/src/experiments/calendar/parent/ext-calendar-provider.js
@@ -76,11 +76,51 @@ function stackContains(part) {
 }
 
 
+// The calendars of one provider type, as the calendar manager currently
+// holds them. That includes the force-disabled placeholders standing in for
+// them while the type is unregistered - which is exactly when this is asked.
+function calendarsOfType(type) {
+  return cal.manager.getCalendars().filter(calendar => calendar.type == type);
+}
+
+// The composite calendars that already exist. cal.view.getCompositeCalendar
+// builds one for a window that has none and installs its manager observer,
+// which is the last thing wanted here, so only windows already holding one
+// are considered. A window with no composite has no opinion to correct.
+function liveComposites() {
+  const composites = [];
+  for (const win of Services.wm.getEnumerator(null)) {
+    if (win._compositeCalendar) {
+      composites.push(win._compositeCalendar);
+    }
+  }
+  return composites;
+}
+
 class ExtCalendarProvider {
   QueryInterface = ChromeUtils.generateQI(["calICalendarProvider"]);
 
   static register(extension) {
     const type = "ext-" + extension.id;
+
+    // Which of ours the user had hidden, asked before anything moves.
+    //
+    // Hiding a calendar *deletes* its calendar-main-in-composite property -
+    // hidden is the absence of the property, not a false. Registering the
+    // type below replaces every placeholder with a real calendar, and that
+    // swap puts the property through two hands: the composite deletes it
+    // when the placeholder unregisters, and cal.view's manager observer
+    // then reads the absence as "a calendar nobody has an opinion about
+    // yet" and shows it. By then an absence the user asked for and one
+    // manufactured a moment ago look identical, so the answer has to be
+    // taken now and put back afterwards.
+    //
+    // Registration is deferred to background-script-started, so this always
+    // runs long after the main window built its composite - there is no
+    // startup order in which the swap goes unobserved.
+    const hidden = calendarsOfType(type)
+      .filter(calendar => !calendar.getProperty("calendar-main-in-composite"))
+      .map(calendar => calendar.id);
 
     cal.manager.registerCalendarProvider(
       type,
@@ -91,14 +131,46 @@ class ExtCalendarProvider {
       }
     );
 
+    // Through the composite rather than by deleting the property again: the
+    // calendar is in the composite by now, and a property nobody acted on
+    // would uncheck the box in the calendar list while the calendar's events
+    // stayed on the view until the next restart. removeCalendar deletes the
+    // property itself, which is what hidden is.
+    for (const id of hidden) {
+      const calendar = cal.manager.getCalendarById(id);
+      if (!calendar) {
+        continue;
+      }
+      for (const composite of liveComposites()) {
+        composite.removeCalendar(calendar);
+      }
+    }
+
     const provider = new ExtCalendarProvider(extension);
     cal.provider.register(provider);
   }
 
   static unregister(extension) {
     const type = "ext-" + extension.id;
+
+    // The same property, lost the other way round: unregistering hands each
+    // calendar to the composite to be removed, and that deletes it. Left
+    // alone, every calendar would look hidden to the register() above, so a
+    // reload, an update or a disable would hide the lot.
+    const visible = calendarsOfType(type)
+      .filter(calendar => calendar.getProperty("calendar-main-in-composite"))
+      .map(calendar => calendar.id);
+
     cal.manager.unregisterCalendarProvider(type, true);
     cal.provider.unregister(type);
+
+    // Writing the property is enough here, and going through the composite
+    // would be wrong: the placeholder that replaced the calendar is
+    // force-disabled, nothing added it to a composite, and adding it would
+    // put a calendar that cannot answer anything onto the view.
+    for (const id of visible) {
+      cal.manager.getCalendarById(id)?.setProperty("calendar-main-in-composite", true);
+    }
   }
 
   constructor(extension) {


### PR DESCRIPTION
This addresses https://github.com/jobisoft/TbSync/issues/817

---
GitHub Copilot summary modified below:

This pull request addresses calendars provided by the extension would become hidden again after restarting, reloading, updating, or disabling and re-enabling the add-on. The fix ensures that the hidden state of calendars is preserved across these events by tracking which calendars were hidden at the time of registration and restoring their visibility state accordingly. 

**Persistence of calendar visibility state:**

* Added logic in `parent/ext-calendar-provider.js` to track which calendars were hidden at the time of registration (`hiddenAtRegistration` set), and to restore their state after register/unregister cycles. This ensures that hidden calendars remain hidden across restarts and reloads. [[1]](diffhunk://#diff-67a8190b96819073fc81b4bae0c3818344b5bd8a7ffd3d6c412cd04bc7f335d6R79-R105) [[2]](diffhunk://#diff-67a8190b96819073fc81b4bae0c3818344b5bd8a7ffd3d6c412cd04bc7f335d6R121-R134)
* Modified the `ExtCalendar.getProperty` method to report hidden calendars as hidden (by returning `false` for `calendar-main-in-composite`) until the property is explicitly set, preventing Thunderbird from mistakenly showing them as visible.

**Documentation and changelog:**

* Added a detailed explanation of the hidden calendar persistence fix to `CHANGES.txt`, including rationale, implementation details, and verification steps. [[1]](diffhunk://#diff-0efda4960444751dc2377fe7b0aa5d398c0bd3987ec03e2298cfad47d9ca7620R291-R342) [[2]](diffhunk://#diff-0efda4960444751dc2377fe7b0aa5d398c0bd3987ec03e2298cfad47d9ca7620L55-R56)

---

Support by Claude Code, Opus 5 and Sonnet 5